### PR TITLE
Create users#edit profile #23

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,6 @@ class ApplicationController < ActionController::Base
   private
 
   def configure_permitted_parameters
-    # サインアップ時にnameも追加で許可する
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
     devise_parameter_sanitizer.permit(:account_update, keys: [:name, :introduction, :avatar])
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,5 +6,6 @@ class ApplicationController < ActionController::Base
   def configure_permitted_parameters
     # サインアップ時にnameも追加で許可する
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :introduction, :avatar])
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,9 +1,15 @@
 class Users::RegistrationsController < Devise::RegistrationsController
   before_action :ensure_normal_user, only: %i[update destroy]
 
+  private
+
   def ensure_normal_user
     if resource.email == 'guest@example.com'
       redirect_to root_path, alert: 'ゲストユーザーの更新・削除はできません。'
     end
+  end
+
+  def update_resource(resource, params)
+    resource.update_without_current_password(params)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,6 +9,7 @@ class UsersController < ApplicationController
   end
 
   def edit_profile
+    @user = User.find(current_user.id)
   end
 
   def account

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,4 +14,18 @@ class User < ApplicationRecord
       user.name = "ゲスト"
     end
   end
+
+  # allow users to update their accounts without passwords
+  def update_without_current_password(params, *options)
+    params.delete(:current_password)
+
+    if params[:password].blank? && params[:password_confirmation].blank?
+      params.delete(:password)
+      params.delete(:password_confirmation)
+    end
+
+    result = update(params, *options)
+    clean_up_passwords
+    result
+  end
 end

--- a/app/views/gadgets/index.html.erb
+++ b/app/views/gadgets/index.html.erb
@@ -5,7 +5,7 @@
 <div>
   <% @gadgets.each do |gadget| %>
     <div>
-      <%= gadget.user.avatar %>
+      <%= image_tag gadget.user.avatar %>
       <p><%= gadget.user.name %></p>
       <p><%= gadget.created_at %></p>
     </div>

--- a/app/views/users/edit_profile.html.erb
+++ b/app/views/users/edit_profile.html.erb
@@ -1,0 +1,24 @@
+<h2>プロフィール編集</h2>
+
+<%= form_with model: @user, url: user_registration_path, method: :patch, local: true do |f| %>
+  <div class="field">
+    <%= f.label :name, "ユーザー名", class: "form-label" %><br />
+    <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "form-control" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :image, "プロフィール画像", class: "form-label" %>
+    <%= f.file_field :image, accept: 'image/jpeg, image/jpg, image/png, image/bmp', class: "form-control" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :introduction, "自己紹介", class: "form-label" %><br />
+    <%= f.text_area :introduction, autocomplete: "introduction", class: "form-control" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "更新" %>
+  </div>
+<% end %>
+
+<%= link_to "戻る", :back %>

--- a/app/views/users/edit_profile.html.erb
+++ b/app/views/users/edit_profile.html.erb
@@ -7,8 +7,8 @@
   </div>
 
   <div class="field">
-    <%= f.label :image, "プロフィール画像", class: "form-label" %>
-    <%= f.file_field :image, accept: 'image/jpeg, image/jpg, image/png, image/bmp', class: "form-control" %>
+    <%= f.label :avatar, "プロフィール画像", class: "form-label" %>
+    <%= f.file_field :avatar, accept: 'image/jpeg, image/jpg, image/png, image/bmp', class: "form-control" %>
   </div>
 
   <div class="field">


### PR DESCRIPTION
#23 
【実装機能概要】

- users#edit_profileのビューの修正
  - 更新時に、name,introductionも更新されるように追加
- users#edit_profileのコントローラーの修正
- パスワード無しでUserの情報を更新できるように設定