### PR TITLE
Design users/registrations#new #39

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,8 +10,17 @@ html {
 body {
   background-color: #F7F7F7;
   color: #393E46;
+  padding-top: 57px;
 }
 
 a {
   text-decoration: none;
+}
+
+h1, h2, h3, h4, h5 {
+  font-weight: bold;
+}
+
+hr {
+  margin: 0;
 }

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -1,3 +1,9 @@
+// common
+header {
+  z-index: 1000;
+  background-color: #F7F7F7;
+}
+
 // logout
 .navbar-toggler-icon {
   width: 3rem;

--- a/app/assets/stylesheets/users/registrations.scss
+++ b/app/assets/stylesheets/users/registrations.scss
@@ -1,0 +1,63 @@
+.container {
+  padding: 20px 32px;
+
+  h2 {
+    font-size: 2.6rem;
+    text-align: center;
+    margin: 20px 0 50px;
+  }
+
+  .label-required {
+    display: flex;
+    align-items: center;
+    margin-bottom: 3px;
+
+    label {
+      font-size: 1.7rem;
+      margin: 0;
+    }
+
+    .minimum-length {
+      font-size: 1.5rem;
+    }
+
+    .required-mark {
+      color: #FFFFFF;
+      background-color: #F17272;
+      font-weight: bold;
+      margin-left: 8px;
+      border-radius: 8px;
+      padding: 2px 6px;
+      display: inline-block;
+      font-size: 0.75em;
+    }
+  }
+
+  input {
+    font-size: 1.5rem;
+    height: 3.5rem;
+  }
+
+  .actions .btn {
+    background-color: #393E46;
+    color: #F7F7F7;
+    height: 4rem;
+    font-size: 2rem;
+    font-weight: 550;
+  }
+
+  p {
+    font-size: 1.2rem;
+  }
+
+  .login-link {
+    text-align: center;
+    margin: 50px 0 30px;
+
+    a {
+      color: #679EF1;
+      font-size: 2rem;
+      font-weight: 550;
+    }
+  }
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,10 @@
 class User < ApplicationRecord
+  MAX_USER_NAME_LENGTH = 20
+
   has_many :gadgets
   has_one_attached :avatar
+
+  validates :name, presence: true, length: { maximum: MAX_USER_NAME_LENGTH }, uniqueness: { case_sensitive: false }
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,34 +1,51 @@
-<h2>ユーザー新規登録</h2>
+<div class="container">
+  <h2>ユーザー新規登録</h2>
 
-<%= form_with model: @user, url: user_registration_path, local: true do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= form_with model: @user, url: user_registration_path, local: true do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :name, class: "form-label" %><br />
-    <%= f.text_field :name, autofocus: true, autocomplete: "username", class: "form-control" %>
+    <div class="field mb-5">
+      <div class="label-required">
+        <%= f.label :name, class: "form-label" %>
+        <span class="minimum-length"><%= "(#{User::MAX_USER_NAME_LENGTH}文字以上)" %></span>
+        <span class="required-mark">必須</span>
+      </div>
+      <%= f.text_field :name, autofocus: true, autocomplete: "username", class: "form-control" %>
+    </div>
+
+    <div class="field mb-5">
+      <div class="label-required">
+        <%= f.label :email, class: "form-label" %><span class="required-mark">必須</span>
+      </div>
+      <%= f.email_field :email, autocomplete: "email", class: "form-control" %>
+    </div>
+
+    <div class="field mb-5">
+      <div class="label-required">
+        <%= f.label :password, class: "form-label" %>
+        <span class="minimum-length"><%= "（#{@minimum_password_length}文字以上）" if @minimum_password_length %></span>
+        <span class="required-mark">必須</span>
+      </div>
+      <%= f.password_field :password, autocomplete: "new-password", class: "form-control" %>
+    </div>
+
+    <div class="field mb-5">
+      <div class="label-required">
+        <%= f.label :password_confirmation, class: "form-label" %><span class="required-mark">必須</span>
+      </div>
+      <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control" %>
+    </div>
+
+    <div class="actions mb-3 pt-4 d-grid mx-auto">
+      <%= f.submit "登録", class: "btn" %>
+    </div>
+  <% end %>
+
+  <p>ユーザーが本サービスへの登録申込をしたことをもって利用規約およびプライバシーポリシーのすべての条項に同意したものとみなします。</p>
+
+  <div class="login-link">
+    <%= link_to "ログインはこちら", user_session_path %>
   </div>
 
-  <div class="field">
-    <%= f.label :email, class: "form-label" %><br />
-    <%= f.email_field :email, autocomplete: "email", class: "form-control" %>
-  </div>
 
-  <div class="field">
-    <%= f.label :password, class: "form-label" %>
-    <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
-    <% end %><br />
-    <%= f.password_field :password, autocomplete: "new-password", class: "form-control" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation, class: "form-label" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "登録" %>
-  </div>
-<% end %>
-
-<%= link_to "ログインはこちら", user_session_path %>
+</div>

--- a/app/views/shared/_login_user_header.html.erb
+++ b/app/views/shared/_login_user_header.html.erb
@@ -1,4 +1,4 @@
-<header>
+<header class="fixed-top">
   <nav class="navbar navbar-expand-lg navbar-light">
     <div class="container-fluid">
       <%= link_to root_path, class: "navbar-brand" do %>
@@ -20,4 +20,5 @@
       </div>
     </div>
   </nav>
+  <hr>
 </header>

--- a/app/views/shared/_logout_user_header.html.erb
+++ b/app/views/shared/_logout_user_header.html.erb
@@ -1,4 +1,4 @@
-<header>
+<header class="fixed-top">
   <nav class="navbar navbar-expand-lg navbar-light">
     <div class="container-fluid">
       <%= link_to root_path, class: "navbar-brand" do %>
@@ -18,4 +18,5 @@
       </div>
     </div>
   </nav>
+  <hr>
 </header>


### PR DESCRIPTION
#39 
【実装機能概要】

- 新規登録ページ（users/registrations#new）のデザインの実装
- ヘッダーの上部固定化
- ユーザー名に関するバリデーションの追加