### PR TITLE
プロフィール編集ページのモバイルデザイン作成 #52

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,3 +16,4 @@
 @import "gadgets/new";
 @import "users/account";
 @import "users/registrations/edit";
+@import "users/edit_profile";

--- a/app/assets/stylesheets/users/_edit_profile.scss
+++ b/app/assets/stylesheets/users/_edit_profile.scss
@@ -1,0 +1,2 @@
+@import "components/forms";
+@import "components/buttons";

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,6 +1,17 @@
 class Users::RegistrationsController < Devise::RegistrationsController
   before_action :ensure_normal_user, only: %i[update destroy]
 
+  def update
+    super do |resource|
+      if resource.errors.empty?
+        case params[:form_type]
+        when 'profile_edit' then redirect_to user_mygadgets_path(current_user.id) and return
+        when 'account_edit' then redirect_to user_account_path(current_user.id) and return
+        end
+      end
+    end
+  end
+
   private
 
   def ensure_normal_user

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -36,6 +36,8 @@
       <%= f.password_field :current_password, autocomplete: "current-password", class: "form-control" %>
     </div>
 
+    <%= hidden_field_tag :form_type, 'account_edit' %>
+
     <div class="actions mb-3 pt-4 d-grid mx-auto">
       <%= f.submit "更新", class: "btn" %>
     </div>

--- a/app/views/users/edit_profile.html.erb
+++ b/app/views/users/edit_profile.html.erb
@@ -1,24 +1,32 @@
-<h2>プロフィール編集</h2>
+<div class="container">
+  <h2 class="form-title">プロフィール編集</h2>
 
-<%= form_with model: @user, url: user_registration_path, method: :patch, local: true do |f| %>
-  <div class="field">
-    <%= f.label :name, "ユーザー名", class: "form-label" %><br />
-    <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "form-control" %>
-  </div>
+  <%= form_with model: @user, url: user_registration_path, method: :patch, local: true do |f| %>
+    <div class="field mb-5">
+      <div class="label-container">
+        <%= f.label :name, "ユーザー名", class: "form-label" %>
+      </div>
+      <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "form-control" %>
+    </div>
 
-  <div class="field">
-    <%= f.label :avatar, "プロフィール画像", class: "form-label" %>
-    <%= f.file_field :avatar, accept: 'image/jpeg, image/jpg, image/png, image/bmp', class: "form-control" %>
-  </div>
+    <div class="field mb-5">
+      <div class="label-container">
+        <%= f.label :avatar, "プロフィール画像", class: "form-label" %>
+      </div>
+      <%= f.file_field :avatar, accept: 'image/jpeg, image/jpg, image/png, image/bmp', class: "form-control" %>
+    </div>
 
-  <div class="field">
-    <%= f.label :introduction, "自己紹介", class: "form-label" %><br />
-    <%= f.text_area :introduction, autocomplete: "introduction", class: "form-control" %>
-  </div>
+    <div class="field mb-5">
+      <div class="label-container">
+        <%= f.label :introduction, "自己紹介", class: "form-label" %>
+      </div>
+      <%= f.text_area :introduction, autocomplete: "introduction", class: "form-control", rows: 5 %>
+    </div>
 
-  <div class="actions">
-    <%= f.submit "更新" %>
-  </div>
-<% end %>
+    <%= hidden_field_tag :form_type, 'profile_edit' %>
 
-<%= link_to "戻る", :back %>
+    <div class="actions mb-3 pt-4 d-grid mx-auto">
+      <%= f.submit "更新", class: "btn" %>
+    </div>
+  <% end %>
+</div>


### PR DESCRIPTION
#52 
【実装機能概要】

- プロフィール編集、アカウント情報編集ページのリダイレクト先をそれぞれマイページ、アカウント情報ページになるように修正 
- 上記対応のため、プロフィール編集、アカウント情報編集ページのformに隠しフィールドを追加。隠しフィールドに基づいて、リダイレクト先を分岐する条件をuserコントローラーに追加