### PR TITLE
コメント機能の実装 #66

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,3 +17,4 @@
 @import "users/account";
 @import "users/registrations/edit";
 @import "users/edit_profile";
+@import "comments/index";

--- a/app/assets/stylesheets/comments/_index.scss
+++ b/app/assets/stylesheets/comments/_index.scss
@@ -1,0 +1,3 @@
+.btn:active {
+  border-color: $color-first!important;
+}

--- a/app/assets/stylesheets/gadgets/_show.scss
+++ b/app/assets/stylesheets/gadgets/_show.scss
@@ -10,5 +10,8 @@
   }
 }
 
+.comments-container {
+  margin-top: 80px;
+}
 
 

--- a/app/assets/stylesheets/likes.scss
+++ b/app/assets/stylesheets/likes.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the Likes controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -7,9 +7,10 @@ class CommentsController < ApplicationController
     @comment.user = current_user
 
     if @comment.save
-      # 成功時の処理
+      redirect_to gadget_path(@gadget)
     else
-      # 失敗時の処理
+      flash[:alert] = "コメントの投稿に失敗しました。"
+      render 'gadgets/show'
     end
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,34 @@
+class CommentsController < ApplicationController
+  before_action :authenticate_user!
+
+  def create
+    @gadget = Gadget.find(params[:gadget_id])
+    @comment = @gadget.comments.build(comment_params)
+    @comment.user = current_user
+
+    if @comment.save
+      # 成功時の処理
+    else
+      # 失敗時の処理
+    end
+  end
+
+  def destroy
+    @gadget = Gadget.find(params[:gadget_id])
+    @comment = @gadget.comments.find(params[:id])
+
+    if @comment.user == current_user
+      @comment.destroy
+      # 成功時の処理
+    else
+      # 失敗時の処理
+    end
+  end
+
+  private
+
+  def comment_params
+    params.require(:comment).permit(:content)
+  end
+  
+end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,5 +1,6 @@
 class CommentsController < ApplicationController
   before_action :authenticate_user!
+  before_action :ensure_correct_user, only: [:update, :destroy]
 
   def create
     @gadget = Gadget.find(params[:gadget_id])
@@ -34,6 +35,14 @@ class CommentsController < ApplicationController
 
   def comment_params
     params.require(:comment).permit(:content)
+  end
+
+  def ensure_correct_user
+    comment = Comment.find(params[:id])
+    unless comment.user_id == current_user.id
+      flash[:alert] = "権限がありません。"
+      redirect_to(root_path)
+    end
   end
   
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,6 +1,6 @@
 class CommentsController < ApplicationController
   before_action :authenticate_user!
-  before_action :ensure_correct_user, only: [:update, :destroy]
+  before_action :ensure_correct_user, only: [:destroy]
 
   def create
     @gadget = Gadget.find(params[:gadget_id])

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -26,6 +26,10 @@ class CommentsController < ApplicationController
     end
   end
 
+  def index
+    @gadget = Gadget.find(params[:gadget_id])
+  end
+
   private
 
   def comment_params

--- a/app/controllers/gadgets_controller.rb
+++ b/app/controllers/gadgets_controller.rb
@@ -12,6 +12,7 @@ class GadgetsController < ApplicationController
 
   def show
     @gadget = Gadget.find(params[:id])
+    @comments = @gadget.comments.order('created_at ASC').limit(5)
   end
 
   def new

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,0 +1,2 @@
+module CommentsHelper
+end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -9,10 +9,28 @@ import * as ActiveStorage from "@rails/activestorage"
 import "channels"
 
 import 'jquery/dist/jquery.js'
+import "bootstrap";
+import "../stylesheets/application.scss";
 
 Rails.start()
 Turbolinks.start()
 ActiveStorage.start()
 
-import "bootstrap";
-import "../stylesheets/application.scss";
+
+// コメント一覧ページにてガジェット詳細を開く・閉じる
+document.addEventListener('DOMContentLoaded', () => {
+  const collapseButton = document.querySelector('[data-bs-toggle="collapse"]');
+  const collapseText = collapseButton.querySelector('.collapse-text');
+
+  collapseButton.addEventListener('click', () => {
+    if (collapseButton.getAttribute('aria-expanded') === 'true') {
+      console.log('開く');
+      collapseText.textContent = '▼ ガジェット詳細を閉じる';
+    } else {
+      console.log('閉じる');
+      collapseText.textContent = '▲ ガジェット詳細を見る';
+    }
+  });
+});
+
+

--- a/app/javascript/stylesheets/_custom.scss
+++ b/app/javascript/stylesheets/_custom.scss
@@ -1,0 +1,7 @@
+$light: #F7F7F7;
+$primary: #EEEEEE;
+$secondary: #929AAB;
+$dark: #393E46;
+$info: #679EF1;
+
+// @import "path/to/bootstrap/scss/bootstrap";

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -1,1 +1,2 @@
+@import "custom";
 @import "~bootstrap/scss/bootstrap.scss";

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,4 @@
+class Comment < ApplicationRecord
+  belongs_to :user
+  belongs_to :gadget
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,4 +1,9 @@
 class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :gadget
+
+  validates :content, presence: true, length: { minimum: 1, maximum: 400 }
+  validates :user_id, presence: true
+  validates :gadget_id, presence: true
+
 end

--- a/app/models/gadget.rb
+++ b/app/models/gadget.rb
@@ -2,7 +2,7 @@ class Gadget < ApplicationRecord
   belongs_to :user
   has_one_attached :image
   has_many :likes, dependent: :destroy
-  has_many :commnets, dependent: :destroy
+  has_many :comments, dependent: :destroy
 
   validates :name, presence: true
   validates :category, presence: true

--- a/app/models/gadget.rb
+++ b/app/models/gadget.rb
@@ -2,6 +2,7 @@ class Gadget < ApplicationRecord
   belongs_to :user
   has_one_attached :image
   has_many :likes, dependent: :destroy
+  has_many :commnets, dependent: :destroy
 
   validates :name, presence: true
   validates :category, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   has_many :gadgets, dependent: :destroy
   has_one_attached :avatar
   has_many :likes, dependent: :destroy
+  has_many :comments, dependent: :destroy
 
   validates :name, presence: true, length: { maximum: MAX_USER_NAME_LENGTH }, uniqueness: { case_sensitive: false }
 

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -1,0 +1,91 @@
+<div class="container">
+  <p id="notice"><%= notice %></p>
+
+  <div>
+    <%= link_to user_mygadgets_path(@gadget.user.id) do %>
+      <div class="info-container">
+        <div class="icon-image-md">
+          <%= image_tag @gadget.user.avatar %>
+        </div>
+        <div class="user-name-and-creationdate-md">
+          <p class="user-name-md"><%= @gadget.user.name %></p>
+          <p class="creationdate-md"><%= @gadget.created_at %></p>
+        </div>
+      </div>
+    <% end %>
+  </div>
+
+  <button class="btn mt-4 ps-0" type="button" data-bs-toggle="collapse" data-bs-target="#gadgetDetails" aria-expanded="false" aria-controls="gadgetDetails">
+    <span class="collapse-text fs-5 ">▲ ガジェット詳細を見る</span>
+  </button>
+  <div class="gadget-details-container collapse mt-0 mb-5" id="gadgetDetails">
+    <div class="gadget-detail">
+      <p class="category">ガジェット名</p>
+      <p class="content"><%= @gadget.name %></p>
+    </div>
+    <div class="gadget-detail">
+      <p class="category">カテゴリー</p>
+      <P class="content"><%= @gadget.category %></P>
+    </div>
+    <div class="gadget-detail">
+      <p class="category">使用開始日</p>
+      <P class="content"><%= @gadget.start_date %></P>
+    </div>
+    <div class="gadget-detail">
+      <p class="category">推しポイント</p>
+      <P class="content"><%= safe_join(@gadget.point.split("\n"),tag(:br)) %></P>
+    </div>
+    <div class="gadget-detail">
+      <p class="category">使用用途</p>
+      <P class="content"><%= safe_join(@gadget.usage.split("\n"),tag(:br)) %></P>
+    </div>
+    <div class="gadget-detail">
+      <p class="category">選んだ理由</p>
+      <P class="content"><%= safe_join(@gadget.reason.split("\n"),tag(:br)) %></P>
+    </div>
+  </div>
+
+  <div class="comments-container mt-5">
+    <div class="comments-title justify-content-between d-flex align-items-center border-start border-dark border-5 ps-1 mb-4">
+      <div class="d-flex align-items-center">
+        <h4 class="mb-0 fs-2">コメント</h4>
+        <P class="ms-3 fs-5">全<%= @gadget.comments.count %>件</P>
+      </div>
+    </div>
+    <div class="comments">
+      <% @gadget.comments.each do |comment| %>
+        <div class="comment mb-4">
+          <div class="d-flex justify-content-between mb-2">
+            <div class="d-flex align-items-center">
+              <div class="icon-image-sm">
+                <%= image_tag comment.user.avatar %>
+              </div>
+              <div class="user-name-and-creationdate-sm">
+                <p class="user-name-sm"><%= comment.user.name %></p>
+                <p class="creationdate-sm"><%= comment.created_at %></p>
+              </div>
+            </div>
+            <div class="d-flex align-items-end">
+              <% if comment.user == current_user %>
+                <%= link_to "削除", [comment.gadget, comment], method: :delete, data: { confirm: "本当に削除しますか？" } %>
+              <% end %>
+            </div>
+          </div>
+          <P class="ps-2 fs-5"><%= comment.content %></P>
+        </div>
+      <% end %>
+    </div>
+    <% if user_signed_in? %>
+      <%= form_with(model: [ @gadget, @gadget.comments.build ], local: true) do |form| %>
+        <div class="row mt-5">
+          <div class="col-10">
+            <%= form.text_area :content, rows: 1, class: "form-control h-100" %>
+          </div>
+          <div class="col-2 d-flex align-items-center">
+            <%= form.submit "送信", class: "btn btn-secondary text-light fw-bold fs-5 h-100" %>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -43,6 +43,9 @@
       <p class="category">選んだ理由</p>
       <P class="content"><%= safe_join(@gadget.reason.split("\n"),tag(:br)) %></P>
     </div>
+    <div class="detail-link-container">
+      <%= link_to "＞ ガジェット詳細へ", gadget_path(@gadget), class: "btn detail-link" %>
+    </div>
   </div>
 
   <div class="comments-container mt-5">

--- a/app/views/gadgets/index.html.erb
+++ b/app/views/gadgets/index.html.erb
@@ -25,6 +25,9 @@
               <div class="likes-and-comments-container">
                 <div class="likes-and-comments" id="likes-and-comments-<%= gadget.id %>">
                   <%= render partial: 'shared/likes_and_comments', locals: {gadget: gadget} %>
+                  <%= link_to gadget_comments_path(gadget.id), class: "ms-5" do %>
+                    <i class="fa-regular fa-message fs-2" style="color: #393e46;"></i> <span class="fs-2 ms-2"><%= gadget.comments.count %></span>
+                  <% end %>
                 </div>
               </div>
             </div>

--- a/app/views/gadgets/show.html.erb
+++ b/app/views/gadgets/show.html.erb
@@ -54,4 +54,52 @@
   <div class="edit-btn-container">
     <%= link_to '編集する', edit_gadget_path(@gadget), class: "btn edit-btn" %>
   </div>
+
+  <div class="comments-container">
+    <div class="comments-title justify-content-between d-flex align-items-center border-start border-dark border-5 ps-1 mb-4">
+      <div class="d-flex align-items-center">
+        <h4 class="mb-0 fs-2">コメント</h4>
+        <P class="ms-3 fs-5">全<%= @gadget.comments.count %>件</P>
+      </div>
+      <div>
+        <%= link_to "コメントを全て見る", gadget_comments_path(@gadget.id), class: "fs-5 text-secondary" %>
+      </div>
+    </div>
+    <div class="comments">
+      <% @gadget.comments.each do |comment| %>
+        <div class="comment mb-4">
+          <div class="d-flex justify-content-between mb-2">
+            <div class="d-flex align-items-center">
+              <div class="icon-image-sm">
+                <%= image_tag comment.user.avatar %>
+              </div>
+              <div class="user-name-and-creationdate-sm">
+                <p class="user-name-sm"><%= comment.user.name %></p>
+                <p class="creationdate-sm"><%= comment.created_at %></p>
+              </div>
+            </div>
+            <div class="d-flex align-items-end">
+              <% if comment.user == current_user %>
+                <%= link_to "削除", [comment.gadget, comment], method: :delete, data: { confirm: "本当に削除しますか？" } %>
+              <% end %>
+            </div>
+          </div>
+          <P class="ps-2 fs-5"><%= comment.content %></P>
+        </div>
+      <% end %>
+    </div>
+    <% if user_signed_in? %>
+      <%= form_with(model: [ @gadget, @gadget.comments.build ], local: true) do |form| %>
+        <div class="row mt-5">
+          <div class="col-10">
+            <%= form.text_area :content, rows: 1, class: "form-control h-100" %>
+          </div>
+          <div class="col-2 d-flex align-items-center">
+            <%= form.submit "送信", class: "btn btn-secondary text-light fw-bold fs-5 h-100" %>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+
 </div>

--- a/app/views/gadgets/show.html.erb
+++ b/app/views/gadgets/show.html.erb
@@ -62,7 +62,9 @@
         <P class="ms-3 fs-5">全<%= @gadget.comments.count %>件</P>
       </div>
       <div>
-        <%= link_to "コメントを全て見る", gadget_comments_path(@gadget.id), class: "fs-5 text-secondary" %>
+        <% if @gadget.comments.count >= 6 %>
+          <%= link_to "コメントを全て見る", gadget_comments_path(@gadget.id), class: "fs-5 text-secondary" %>
+        <% end %>
       </div>
     </div>
     <div class="comments">

--- a/app/views/gadgets/top.html.erb
+++ b/app/views/gadgets/top.html.erb
@@ -54,6 +54,9 @@
             <div class="likes-and-comments-container">
               <div class="likes-and-comments" id="likes-and-comments-<%= gadget.id %>">
                 <%= render partial: 'shared/likes_and_comments', locals: {gadget: gadget} %>
+                <%= link_to gadget_comments_path(gadget.id), class: "ms-5" do %>
+                  <i class="fa-regular fa-message fs-2" style="color: #393e46;"></i> <span class="fs-2 ms-2"><%= gadget.comments.count %></span>
+                <% end %>
               </div>
             </div>
           </div>

--- a/app/views/shared/_likes_and_comments.html.erb
+++ b/app/views/shared/_likes_and_comments.html.erb
@@ -1,6 +1,6 @@
 <% if gadget.liked_by?(current_user) %>
   <%= link_to gadget_likes_path(gadget, custom_view: 'other'), method: :delete, remote: true, class: 'like-button' do %>
-    <i class="fas fa-thumbs-up me-2" style="color: black;"></i> <%= gadget.likes.count %>
+    <i class="fas fa-thumbs-up me-2" style="color: #393E46;"></i> <%= gadget.likes.count %>
   <% end %>
 <% else %>
   <% if user_signed_in? %>

--- a/app/views/shared/_likes_and_liked_users.html.erb
+++ b/app/views/shared/_likes_and_liked_users.html.erb
@@ -1,6 +1,6 @@
 <% if gadget.liked_by?(current_user) %>
   <%= link_to gadget_likes_path(gadget, custom_view: 'show'), method: :delete, remote: true, class: 'like-button' do %>
-    <i class="fas fa-thumbs-up me-2" style="color: black;"></i>
+    <i class="fas fa-thumbs-up me-2" style="color: #393E46;"></i>
   <% end %>
   <%= link_to liked_users_gadget_path(gadget), class: 'like-button' do %>
     <P><strong><%= gadget.likes.count %></strong> 件のいいね</P>

--- a/app/views/users/show_favorites.html.erb
+++ b/app/views/users/show_favorites.html.erb
@@ -40,6 +40,9 @@
             <div class="likes-and-comments-container">
               <div class="likes-and-comments" id="likes-and-comments-<%= gadget.id %>">
                 <%= render partial: 'shared/likes_and_comments', locals: {gadget: gadget} %>
+                <%= link_to gadget_comments_path(gadget.id), class: "ms-5" do %>
+                  <i class="fa-regular fa-message fs-2" style="color: #393e46;"></i> <span class="fs-2 ms-2"><%= gadget.comments.count %></span>
+                <% end %>
               </div>
             </div>
           </div>

--- a/app/views/users/show_mygadgets.html.erb
+++ b/app/views/users/show_mygadgets.html.erb
@@ -34,6 +34,9 @@
             <div class="likes-and-comments-container">
               <div class="likes-and-comments" id="likes-and-comments-<%= gadget.id %>">
                 <%= render partial: 'shared/likes_and_comments', locals: {gadget: gadget} %>
+                <%= link_to gadget_comments_path(gadget.id), class: "ms-5" do %>
+                  <i class="fa-regular fa-message fs-2" style="color: #393e46;"></i> <span class="fs-2 ms-2"><%= gadget.comments.count %></span>
+                <% end %>
               </div>
             </div>
             <div class="detail-link-container">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
     end
     resource :likes, only: [:create, :destroy]
     get 'liked_users', on: :member
-    resources :comments, only: [:create, :destroy]
+    resources :comments, only: [:create, :destroy, :index]
   end
 
   devise_for :users,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
     end
     resource :likes, only: [:create, :destroy]
     get 'liked_users', on: :member
+    resources :comments, only: [:create, :destroy]
   end
 
   devise_for :users,

--- a/db/migrate/20230415085634_create_comments.rb
+++ b/db/migrate/20230415085634_create_comments.rb
@@ -1,0 +1,11 @@
+class CreateComments < ActiveRecord::Migration[6.1]
+  def change
+    create_table :comments do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :gadget, null: false, foreign_key: true
+      t.text :content, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_13_135620) do
+ActiveRecord::Schema.define(version: 2023_04_15_085634) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -38,6 +38,16 @@ ActiveRecord::Schema.define(version: 2023_04_13_135620) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "comments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "gadget_id", null: false
+    t.text "content", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["gadget_id"], name: "index_comments_on_gadget_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "gadgets", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -89,6 +99,8 @@ ActiveRecord::Schema.define(version: 2023_04_13_135620) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "comments", "gadgets"
+  add_foreign_key "comments", "users"
   add_foreign_key "gadgets", "users"
   add_foreign_key "likes", "gadgets"
   add_foreign_key "likes", "users"

--- a/erd.pu
+++ b/erd.pu
@@ -34,6 +34,7 @@ entity comments {
   --
   user_id [FK]
   gadget_id [FK]
+  content
 }
 
 entity inquiries as "inquiries\n問い合わせ" {

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CommentsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  gadget: one
+
+two:
+  user: two
+  gadget: two

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CommentTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
#66 
【実装機能概要】

- commentモデルの作成
  - アソシエーションの設定
- commentコントローラーの作成
- Viewの作成
  - トップページにコメントアイコンとコメント数を表示
  - 新着投稿一覧ページにコメントアイコンとコメント数を表示
  - マイページ（My ガジェット）にコメントアイコンとコメント数を表示
  - マイページ（お気に入り）にコメントアイコンとコメント数を表示
  - ガジェット詳細ページにコメント欄を追加
    - コメントは最大５件までの表示に
    - コメント数が６件以上ある場合には、「全てのコメントを見る」リンクが表示されるように
  - コメントページを新規追加
    - ガジェット詳細ページへのリンクボタンを作成
- ルーティングの設定
- バリデーションの追加
- セキュリティ対策
  - 認証されたユーザーのみがコメントを投稿できるようにする
  - 他のユーザーのコメントを削除できないようにする