### PR TITLE
トップページのPC／タブレット用デザインの実装 #73

### DIFF
--- a/app/assets/stylesheets/base/_typography.scss
+++ b/app/assets/stylesheets/base/_typography.scss
@@ -15,7 +15,8 @@ a {
 }
 
 a:hover {
-  color: $color-fourth;
+  // color: $color-fourth;
+  opacity: 0.7;
 }
 
 h1, h2, h3, h4, h5 {
@@ -30,6 +31,28 @@ p {
   margin: 0;
 }
 
-.container {
+.wrapper {
   padding: 20px 32px 70px;
+}
+
+.container {
+  padding: 0 32px;
+}
+
+
+// margin
+.mt-48 {
+  margin-top: 48px;
+}
+
+.mt-56 {
+  margin-top: 56px;
+}
+
+.mt-64 {
+  margin-top: 64px;
+}
+
+.mt-80 {
+  margin-top: 80px;
 }

--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -15,16 +15,18 @@
 
 // 一覧ページへのリンクボタン
 .list-link-container {
-  padding: 0 15px;
+  // padding: 0 15px;
 
   .list-link {
     display: block;
     background-color: $color-second;
     text-align: center;
-    padding: 8px 0;
+    padding: 12px 0;
     color: $color-fourth;
     font-size: 1.5rem;
     font-weight: bold;
+    width: 80%;
+    margin: 0 auto;
   }
 }
 

--- a/app/assets/stylesheets/components/_parts.scss
+++ b/app/assets/stylesheets/components/_parts.scss
@@ -42,25 +42,34 @@
 // ガジェット画像（小）
 .gadget-image-sm {
   margin: 12px 0;
-  padding: 0 8px;
+  padding: 0 4px;
 
-  a + a {
-    margin-left: 7px;
+  a {
+    width: 100%;
+  }
+
+  // a + a {
+  //   margin-left: 7px;
+  // }
+
+  img {
+    width: 100%;
+    height: 95px;
   }
 }
 
 // アイコン画像（小）
 .icon-image-sm {
-  display: inline-block;
+  display: block;
   width: 37px;
   height: 37px;
   border-radius: 50%;
-  overflow: hidden;
+  // overflow: hidden;
 
   img {
     display: block;
-    width: 100%;
-    height: 100%;
+    width: 37px;
+    height: 37px;
     object-fit: cover;
   }
 }
@@ -185,5 +194,39 @@
 
   strong {
     font-size: 1.7rem;
+  }
+}
+
+
+// 画面幅500px以上の場合
+@media screen and (min-width:500px) {
+
+  .gadget-image-sm {
+
+    img {
+      height: 115px;
+    }
+  }
+}
+
+// 画面幅768px~991pxの場合
+@media screen and (min-width:768px) and ( max-width:991px) {
+
+  .gadget-image-sm {
+
+    img {
+      height: 85px;
+    }
+  }
+}
+
+// 画面幅1400px以上の場合
+@media screen and (min-width:1400px) {
+
+  .gadget-image-sm {
+
+    img {
+      height: 85px;
+    }
   }
 }

--- a/app/assets/stylesheets/gadgets/_top.scss
+++ b/app/assets/stylesheets/gadgets/_top.scss
@@ -36,42 +36,6 @@
   }
 }
 
-// registration-and-login
-.registration-and-login {
-  padding-top: 15px;
-  padding-bottom: 40px;
-
-  .registration-button {
-    text-align: center;
-    padding-bottom: 20px;
-
-    .registration {
-      font-size: 19px;
-    }
-  }
-
-  .login-button {
-    display: flex;
-    justify-content: space-between;
-    padding: 0 50px;
-
-    .login {
-      font-size: 19px;
-    }
-
-    .guest-login {
-      font-size: 16px;
-    }
-  }
-
-  .btn {
-    background: $color-fourth;
-    color: $color-first;
-    width:  130px;
-    height: 40px;
-  }
-}
-
 // 一覧部分タイトル
 .lists-title {
   display: flex;

--- a/app/assets/stylesheets/gadgets/_top.scss
+++ b/app/assets/stylesheets/gadgets/_top.scss
@@ -52,3 +52,41 @@
     font-size: 1.2rem;
   }
 }
+
+
+.gadget-image-md {
+  width: 38%;
+  height: 132px;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+}
+
+
+// 画面幅500px以上の場合
+@media screen and (min-width:500px) {
+
+  .gadget-image-md {
+    width: 45%;
+    height: 132px;
+  }
+}
+
+// 画面幅768px以上の場合
+@media screen and (min-width:768px) {
+
+  .lists-title {
+
+    h2 {
+      font-size: 2.3rem;
+    }
+
+    a {
+      font-size: 1.5rem;
+    }
+  }
+}

--- a/app/assets/stylesheets/layouts/_header.scss
+++ b/app/assets/stylesheets/layouts/_header.scss
@@ -25,6 +25,25 @@ header {
   font-size: 1.5rem;
 }
 
+// 4/21~
+.nav-link {
+  color: $color-fourth;
+  font-size: 1.3rem;
+  font-weight: bold;
+}
+
+.nav-link:hover {
+  opacity: 0.7;
+  box-shadow: inset 0 -4px 0 0 $color-fourth;
+}
+
+.dropdown-item {
+  color: $color-first;
+  font-size: 1.5rem;
+  margin-bottom: 10px;
+}
+
+
 
 // login
 .avatar-wrapper ul {

--- a/app/controllers/gadgets_controller.rb
+++ b/app/controllers/gadgets_controller.rb
@@ -2,8 +2,8 @@ class GadgetsController < ApplicationController
   before_action :set_gadget, only: %i[ show edit update destroy ]
 
   def top
-    @gadgets = Gadget.all.order('created_at DESC').limit(5)
-    @users = User.all.order('created_at DESC').limit(5)
+    @gadgets = Gadget.all.order('created_at DESC').limit(10)
+    @users = User.all.order('created_at DESC').limit(10)
   end
 
   def index

--- a/app/views/gadgets/top.html.erb
+++ b/app/views/gadgets/top.html.erb
@@ -11,19 +11,25 @@
   </div>
 </div>
 <% unless user_signed_in? %>
-  <div class="registration-and-login">
-    <div class="registration-button">
-      <%= link_to new_user_registration_path do %>
-        <button type="button" class="btn registration">新規登録</button>
-      <% end %>
+  <div class="container">
+    <div class="row justify-content-center">
+      <div class="col-lg-3 col-6 text-center">
+        <%= link_to new_user_registration_path, class: "d-block d-grid" do %>
+          <button type="button" class="btn bg-dark text-light fs-2 fw-bold py-3">新規登録</button>
+        <% end %>
+      </div>
     </div>
-    <div class="login-button">
-      <%= link_to new_user_session_path do %>
-        <button type="button" class="btn login">ログイン</button>
-      <% end %>
-      <%= link_to users_guest_sign_in_path do %>
-        <button type="button" class="btn guest-login">ゲストログイン</button>
-      <% end %>
+    <div class="row justify-content-center gx-5 mt-4">
+      <div class="col-lg-3 col-6 text-center">
+        <%= link_to new_user_session_path, class: "d-block d-grid" do %>
+          <button type="button" class="btn bg-dark text-light fs-2 fw-bold py-3">ログイン</button>
+        <% end %>
+      </div>
+      <div class="col-lg-3 col-6 text-center">
+        <%= link_to users_guest_sign_in_path, class: "d-block d-grid" do %>
+          <button type="button" class="btn bg-dark text-light fs-2 fw-bold py-3">ゲストログイン</button>
+        <% end %>
+      </div>
     </div>
   </div>
 <% end %>

--- a/app/views/gadgets/top.html.erb
+++ b/app/views/gadgets/top.html.erb
@@ -11,7 +11,7 @@
   </div>
 </div>
 <% unless user_signed_in? %>
-  <div class="container">
+  <div class="container mt-48">
     <div class="row justify-content-center">
       <div class="col-lg-3 col-6 text-center">
         <%= link_to new_user_registration_path, class: "d-block d-grid" do %>
@@ -33,98 +33,110 @@
     </div>
   </div>
 <% end %>
-<div class="container">
+<div class="container mt-64">
   <div class="lists-title">
     <h2>新着投稿一覧</h2>
     <%= link_to "新着投稿一覧はこちら", gadgets_path %>
   </div>
   <div class="lists">
-    <% @gadgets.each do |gadget| %>
-      <div class="list-item">
-        <div class="post-container">
-          <div class="content">
-            <%= link_to mygadgets_user_path(gadget.user.id) do %>
-              <div class="info-container">
-                <div class="icon-image-sm">
-                  <%= image_tag gadget.user.avatar %>
-                </div>
-                <div class="user-name-and-creationdate-sm">
-                  <p class="user-name-sm"><%= gadget.user.name %></p>
-                  <p class="creationdate-sm"><%= gadget.created_at %></p>
+    <div class="row g-4">
+      <% @gadgets.each do |gadget| %>
+        <div class="col-md-6 col-xxl-4">
+          <div class="list-item">
+            <div class="post-container">
+              <div class="content">
+                <%= link_to mygadgets_user_path(gadget.user.id) do %>
+                  <div class="info-container">
+                    <div class="icon-image-sm">
+                      <%= image_tag gadget.user.avatar %>
+                    </div>
+                    <div class="user-name-and-creationdate-sm">
+                      <p class="user-name-sm"><%= gadget.user.name %></p>
+                      <p class="creationdate-sm"><%= gadget.created_at %></p>
+                    </div>
+                  </div>
+                <% end %>
+                <p class="gadget-name"><%= gadget.name %></p>
+                <p class="gadget-category"><%= gadget.category %></p>
+                <%# いいねとコメント %>
+                <div class="likes-and-comments-container">
+                  <div class="likes-and-comments" id="likes-and-comments-<%= gadget.id %>">
+                    <%= render partial: 'shared/likes_and_comments', locals: {gadget: gadget} %>
+                    <%= link_to gadget_comments_path(gadget.id), class: "ms-5" do %>
+                      <i class="fa-regular fa-message fs-2" style="color: #393e46;"></i> <span class="fs-2 ms-2"><%= gadget.comments.count %></span>
+                    <% end %>
+                  </div>
                 </div>
               </div>
-            <% end %>
-            <p class="gadget-name"><%= gadget.name %></p>
-            <p class="gadget-category"><%= gadget.category %></p>
-            <%# いいねとコメント %>
-            <div class="likes-and-comments-container">
-              <div class="likes-and-comments" id="likes-and-comments-<%= gadget.id %>">
-                <%= render partial: 'shared/likes_and_comments', locals: {gadget: gadget} %>
-                <%= link_to gadget_comments_path(gadget.id), class: "ms-5" do %>
-                  <i class="fa-regular fa-message fs-2" style="color: #393e46;"></i> <span class="fs-2 ms-2"><%= gadget.comments.count %></span>
-                <% end %>
+              <div class="gadget-image-md">
+                <%= image_tag gadget.image %>
               </div>
             </div>
-          </div>
-          <div class="gadget-image-md">
-            <%= image_tag gadget.image, size: "125x110" %>
+            <div class="detail-link-container">
+              <%= link_to "＞ 投稿詳細へ", gadget_path(gadget), class: "btn detail-link" %>
+            </div>
           </div>
         </div>
-        <div class="detail-link-container">
-          <%= link_to "＞ 投稿詳細へ", gadget_path(gadget), class: "btn detail-link" %>
-        </div>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
   </div>
   <div class="list-link-container">
     <%= link_to "新着投稿一覧はこちら", gadgets_path, class: "btn list-link" %>
   </div>
 </div>
-<div class="container">
+<div class="container mt-80">
   <div class="lists-title">
     <h2>ユーザー一覧</h2>
     <%= link_to "ユーザー一覧はこちら", users_path %>
   </div>
   <div class="lists">
-    <% @users.each do |user| %>
-      <div class="list-item">
-        <div class="d-flex justify-content-between align-items-center">
-          <%= link_to mygadgets_user_path(user.id) do %>
-            <div class="info-container">
-              <div class="icon-image-sm">
-                <%= image_tag user.avatar %>
-              </div>
-              <div class="user-name-only">
-                <p class="user-name"><%= user.name %></p>
+    <div class="row g-4">
+      <% @users.each do |user| %>
+        <div class="col-md-6 col-xxl-4">
+          <div class="list-item">
+            <div class="d-flex justify-content-between align-items-center">
+              <%= link_to mygadgets_user_path(user.id) do %>
+                <div class="info-container">
+                  <div class="icon-image-sm">
+                    <%= image_tag user.avatar %>
+                  </div>
+                  <div class="user-name-only">
+                    <p class="user-name"><%= user.name %></p>
+                  </div>
+                </div>
+              <% end %>
+              <% if user_signed_in? %>
+                <div id="follow-form-<%= user.id %>">
+                  <%= render 'shared/follow-and-unfollow', user: user %>
+                </div>
+              <% end %>
+            </div>
+            <div class="gadget-image-sm">
+              <div class="row">
+                <% user.gadgets.each do |gadget| %>
+                  <div class="col-3">
+                    <%= link_to gadget_path(gadget.id) do %>
+                      <%= image_tag gadget.image %>
+                    <% end %>
+                  </div>
+                <% end %>
               </div>
             </div>
-          <% end %>
-          <% if user_signed_in? %>
-            <div id="follow-form-<%= user.id %>">
-              <%= render 'shared/follow-and-unfollow', user: user %>
+            <div class="ps-2">
+              <%= link_to user_followings_path(user) do %>
+                <span class="fs-5"><strong><%= user.followings.count %></strong> フォロー</span>
+              <% end %>
+              <%= link_to user_followers_path(user) do %>
+                <span class="fs-5 ms-4"><strong><%= user.followers.count %></strong> フォロワー</span>
+              <% end %>
             </div>
-          <% end %>
+            <div class="detail-link-container">
+              <P><%= link_to "＞ ユーザー詳細へ", users_path(user.id), class: "btn detail-link" %></P>
+            </div>
+          </div>
         </div>
-        <div class="gadget-image-sm">
-          <% user.gadgets.each do |gadget| %>
-            <%= link_to gadget_path(gadget.id) do %>
-              <%= image_tag gadget.image, size: "65x65" %>
-            <% end %>
-          <% end %>
-        </div>
-        <div>
-          <%= link_to user_followings_path(user) do %>
-            <span class="fs-5"><strong><%= user.followings.count %></strong> フォロー</span>
-          <% end %>
-          <%= link_to user_followers_path(user) do %>
-            <span class="fs-5 ms-4"><strong><%= user.followers.count %></strong> フォロワー</span>
-          <% end %>
-        </div>
-        <div class="detail-link-container">
-          <P><%= link_to "＞ ユーザー詳細へ", users_path(user.id), class: "btn detail-link" %></P>
-        </div>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
   </div>
   <div class="list-link-container">
     <P><%= link_to "ユーザー一覧はこちら", users_path, class: "btn list-link" %></P>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer>
+<footer class="mt-80">
   <hr>
   <div class="logo">
     <%= image_tag "logo.jpg", size: "200x70" %>

--- a/app/views/shared/_login_user_header.html.erb
+++ b/app/views/shared/_login_user_header.html.erb
@@ -1,5 +1,5 @@
 <header class="fixed-top">
-  <nav class="navbar navbar-expand-lg navbar-light">
+  <nav class="navbar navbar-expand-lg navbar-light px-4">
     <div class="container-fluid">
       <%= link_to root_path, class: "navbar-brand" do %>
         <%= image_tag "logo.jpg", size: "130x40" %>

--- a/app/views/shared/_logout_user_header.html.erb
+++ b/app/views/shared/_logout_user_header.html.erb
@@ -1,5 +1,5 @@
 <header class="fixed-top">
-  <nav class="navbar navbar-light">
+  <nav class="navbar navbar-light px-4">
     <div class="container-fluid">
       <div class="d-flex align-items-center">
         <%= link_to root_path, class: "navbar-brand" do %>

--- a/app/views/shared/_logout_user_header.html.erb
+++ b/app/views/shared/_logout_user_header.html.erb
@@ -1,21 +1,34 @@
 <header class="fixed-top">
-  <nav class="navbar navbar-expand-lg navbar-light">
+  <nav class="navbar navbar-light">
     <div class="container-fluid">
-      <%= link_to root_path, class: "navbar-brand" do %>
-        <%= image_tag "logo.jpg", size: "130x40" %>
-      <% end %>
-      <div class="humberger-wrapper">
-        <a class="avatar-link" href="#" role="button" id="navbarDropdown" data-bs-toggle="dropdown" aria-expanded="false">
-          <span class="navbar-toggler-icon"></span>
-        </a>
-        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
-          <li><%= link_to "新規登録", new_user_registration_path, class: "nav-link active", 'aria-current': "page" %></li>
-          <li><%= link_to "ログイン", new_user_session_path, class: "nav-link" %></li>
-          <li><%= link_to "ユーザー一覧", users_path, class: "nav-link" %></li>
-          <li><%= link_to "新着投稿一覧", gadgets_path, class: "nav-link" %></li>
-          <li><%= link_to "お問い合わせ", root_path, class: "nav-link" %></li>
+      <div class="d-flex align-items-center">
+        <%= link_to root_path, class: "navbar-brand" do %>
+          <%= image_tag "logo.jpg", size: "130x40" %>
+        <% end %>
+        <ul class="navbar-nav d-none d-lg-flex flex-row ms-4">
+          <li class="nav-item"><%= link_to "新着投稿一覧", gadgets_path, class: "nav-link" %></li>
+          <li class="nav-item ms-4"><%= link_to "ユーザー一覧", users_path, class: "nav-link" %></li>
         </ul>
       </div>
+      <div class="d-lg-none">
+        <div class="dropdown">
+          <button class="btn btn-secondary dropdown-toggle bg-primary" type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-expanded="false">
+            <span class="navbar-toggler-icon"></span>
+          </button>
+          <ul class="dropdown-menu dropdown-menu-end bg-secondary px-4 pt-3" aria-labelledby="dropdownMenuButton">
+            <li><%= link_to "新規登録", new_user_registration_path, class: "dropdown-item" %></li>
+            <li><%= link_to "ログイン", new_user_session_path, class: "dropdown-item" %></li>
+            <li><%= link_to "ユーザー一覧", users_path, class: "dropdown-item" %></li>
+            <li><%= link_to "新着投稿一覧", gadgets_path, class: "dropdown-item" %></li>
+            <li><%= link_to "お問い合わせ", root_path, class: "dropdown-item" %></li>
+          </ul>
+        </div>
+      </div>
+      <ul class="navbar-nav d-none d-lg-flex flex-row">
+        <li class="nav-item"><%= link_to "新規登録", new_user_registration_path, class: "nav-link" %></li>
+        <li class="nav-item mx-4"><%= link_to "ログイン", new_user_session_path, class: "nav-link" %></li>
+        <li class="nav-item me-3"><%= link_to "お問い合わせ", root_path, class: "nav-link" %></li>
+      </ul>
     </div>
   </nav>
   <hr>


### PR DESCRIPTION
#73 
【実装機能概要】

- ヘッダーを992px以上でハンバーガーメニューから展開メニューへ
- 新規登録・ログイン・ゲストログインボタンを992pxを境に大きさが変わるよう修正
- 「新着投稿一覧」、「新着投稿一覧はこちら」、「ユーザー一覧」、「ユーザー一覧はこちら」の文字の大きさを768px以上で変わるよう修正
- 「新着投稿一覧はこちら」、「ユーザー一覧はこちら」の文字色をホバー時に薄くなるよう修正
- 新着投稿一覧、ユーザー一覧の投稿を768px、1400pxで２列、３列になるよう修正
- 一覧ページへのリンクボタンの幅をレスポンシブ対応