### PR TITLE
ユーザー情報更新時の現在のパスワードの有無について、更新項目毎に場合分けされるよう修正 #134

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -21,6 +21,12 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def update_resource(resource, params)
-    resource.update_without_current_password(params)
+    if params[:email].present? || params[:password].present?
+      # メールアドレス/パスワードの更新の場合には現在のパスワードが必要
+      resource.update_with_password(params)
+    else
+      # ユーザー名/自己紹介/アバター画像の更新の場合には現在のパスワードは不要
+      resource.update_without_current_password(params)
+    end
   end
 end


### PR DESCRIPTION
#134 
【実装機能概要】

- ユーザー情報更新時の現在のパスワードの有無について、更新項目毎に場合分けされるよう修正
  - ユーザー名／自己紹介／アイコン画像の変更時には現在のパスワード不要
  - メールアドレス／パスワードの変更時には現在のパスワード必要