### PR TITLE
ユーザー一覧ページ等の各ユーザー欄にもフォローとフォロワー数を表示させる #131

### DIFF
--- a/app/views/gadgets/liked_users.html.erb
+++ b/app/views/gadgets/liked_users.html.erb
@@ -9,7 +9,7 @@
           <%= link_to mygadgets_user_path(user.id) do %>
             <div class="info-container">
               <div class="icon-image-sm">
-                <%= image_tag user.avatar %>
+                <%= user_avatar_image_tag(user) %>
               </div>
               <div class="user-name-only">
                 <p class="user-name"><%= user.name %></p>
@@ -23,7 +23,15 @@
         <div class="user-introduction">
           <p><%= user.introduction %></p>
         </div>
-        <div class="detail-link-container">
+        <div class="ps-3 mt-4">
+          <%= link_to user_followings_path(user) do %>
+            <span class="fs-5"><strong><%= user.followings.count %></strong> フォロー</span>
+          <% end %>
+          <%= link_to user_followers_path(user) do %>
+            <span class="fs-5 ms-4"><strong><%= user.followers.count %></strong> フォロワー</span>
+          <% end %>
+        </div>
+        <div class="detail-link-container mt-4">
           <P><%= link_to "＞ ユーザー詳細へ", users_path(user.id), class: "btn detail-link" %></P>
         </div>
       </div>

--- a/app/views/relationships/followers.html.erb
+++ b/app/views/relationships/followers.html.erb
@@ -21,7 +21,7 @@
           <%= link_to mygadgets_user_path(user.id) do %>
             <div class="info-container">
               <div class="icon-image-sm">
-                <%= image_tag user.avatar %>
+                <%= user_avatar_image_tag(user) %>
               </div>
               <div class="user-name-only">
                 <p class="user-name"><%= user.name %></p>

--- a/app/views/relationships/followers.html.erb
+++ b/app/views/relationships/followers.html.erb
@@ -37,7 +37,15 @@
         <div class="user-introduction">
           <p><%= user.introduction %></p>
         </div>
-        <div class="detail-link-container">
+        <div class="ps-3 mt-4">
+          <%= link_to user_followings_path(user) do %>
+            <span class="fs-5"><strong><%= user.followings.count %></strong> フォロー</span>
+          <% end %>
+          <%= link_to user_followers_path(user) do %>
+            <span class="fs-5 ms-4"><strong><%= user.followers.count %></strong> フォロワー</span>
+          <% end %>
+        </div>
+        <div class="detail-link-container mt-4">
           <P><%= link_to "＞ ユーザー詳細へ", users_path(user.id), class: "btn detail-link" %></P>
         </div>
       </div>

--- a/app/views/relationships/followings.html.erb
+++ b/app/views/relationships/followings.html.erb
@@ -21,7 +21,7 @@
           <%= link_to mygadgets_user_path(user.id) do %>
             <div class="info-container">
               <div class="icon-image-sm">
-                <%= image_tag user.avatar %>
+                <%= user_avatar_image_tag(user) %>
               </div>
               <div class="user-name-only">
                 <p class="user-name"><%= user.name %></p>

--- a/app/views/relationships/followings.html.erb
+++ b/app/views/relationships/followings.html.erb
@@ -37,7 +37,15 @@
         <div class="user-introduction">
           <p><%= user.introduction %></p>
         </div>
-        <div class="detail-link-container">
+        <div class="ps-3 mt-4">
+          <%= link_to user_followings_path(user) do %>
+            <span class="fs-5"><strong><%= user.followings.count %></strong> フォロー</span>
+          <% end %>
+          <%= link_to user_followers_path(user) do %>
+            <span class="fs-5 ms-4"><strong><%= user.followers.count %></strong> フォロワー</span>
+          <% end %>
+        </div>
+        <div class="detail-link-container mt-4">
           <P><%= link_to "＞ ユーザー詳細へ", users_path(user.id), class: "btn detail-link" %></P>
         </div>
       </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -31,6 +31,14 @@
             <% end %>
           <% end %>
         </div>
+        <div class="ps-2">
+          <%= link_to user_followings_path(user) do %>
+            <span class="fs-5"><strong><%= user.followings.count %></strong> フォロー</span>
+          <% end %>
+          <%= link_to user_followers_path(user) do %>
+            <span class="fs-5 ms-4"><strong><%= user.followers.count %></strong> フォロワー</span>
+          <% end %>
+        </div>
         <div class="detail-link-container">
           <P><%= link_to "＞ ユーザー詳細へ", mygadgets_user_path(user.id), class: "btn detail-link" %></P>
         </div>


### PR DESCRIPTION
#131 
【実装機能概要】

- ユーザー一覧ページに表示
- いいねしたユーザー一覧ページに表示
- フォロー一覧ページに表示
- フォロワー一覧ページに表表示