### PR TITLE
formのページのレスポンシブデザインの実装

### DIFF
--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,32 +1,34 @@
-<div class="container">
-  <h2 class="form-title mb-3">パスワード再設定</h2>
-  <p class="form-title-description">ご登録のメールアドレス宛に再設定用のURLをお送りいたします。</p>
+<div class="container mt-80">
+  <div class="responsive-container">
+    <h2 class="form-title mb-3">パスワード再設定</h2>
+    <p class="form-title-description">ご登録のメールアドレス宛に再設定用のURLをお送りいたします。</p>
 
-  <%= form_with model: @user, url: user_password_path, local: true do |f| %>
-    <%= render "devise/shared/error_messages", resource: resource %>
+    <%= form_with model: @user, url: user_password_path, local: true do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
 
-    <div class="field mb-5">
-      <div class="label-container">
-        <%= f.label :email, class: "form-label" %>
+      <div class="field mb-5">
+        <div class="label-container">
+          <%= f.label :email, class: "form-label" %>
+        </div>
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>
       </div>
-      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>
-    </div>
 
-    <div class="actions mb-5 pt-4 d-grid mx-auto">
-      <%= f.submit "送信", class: "btn" %>
-    </div>
-  <% end %>
+      <div class="actions mb-5 pt-4 d-grid mx-auto">
+        <%= f.submit "送信", class: "btn" %>
+      </div>
+    <% end %>
 
-  <div class="no-account-container pt-5">
-    <hr>
-    <h3 class="no-account-title">アカウントをお持ちでない方</h3>
-    <div class="guest-user-btn d-grid mx-auto mb-5">
-      <h4>ゲストユーザーとしてログインする</h4>
-      <%= link_to "ゲストログイン", users_guest_sign_in_path, method: :post, class: "btn" %>
-    </div>
-    <div class="registration-btn d-grid mx-auto pt-4">
-      <h4>新しくアカウントを作成する</h4>
-      <%= link_to "新規登録ページへ", new_user_registration_path, class: "btn" %>
+    <div class="no-account-container pt-5">
+      <hr>
+      <h3 class="no-account-title">アカウントをお持ちでない方</h3>
+      <div class="guest-user-btn d-grid mx-auto mb-5">
+        <h4>ゲストユーザーとしてログインする</h4>
+        <%= link_to "ゲストログイン", users_guest_sign_in_path, method: :post, class: "btn" %>
+      </div>
+      <div class="registration-btn d-grid mx-auto pt-4">
+        <h4>新しくアカウントを作成する</h4>
+        <%= link_to "新規登録ページへ", new_user_registration_path, class: "btn" %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,45 +1,47 @@
-<div class="container">
-  <h2 class="form-title">アカウント情報を編集</h2>
+<div class="container mt-80">
+  <div class="responsive-container">
+    <h2 class="form-title">アカウント情報を編集</h2>
 
-  <%= form_with model: @user, url: user_registration_path, local: true do |f| %>
-    <%= render "devise/shared/error_messages", resource: resource %>
+    <%= form_with model: @user, url: user_registration_path, local: true do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
 
-    <div class="field mb-5">
-      <div class="label-container">
-        <%= f.label :email, class: "form-label" %>
+      <div class="field mb-5">
+        <div class="label-container">
+          <%= f.label :email, class: "form-label" %>
+        </div>
+        <%= f.email_field :email, value: @user.email, autofocus: true, autocomplete: "email", class: "form-control" %>
       </div>
-      <%= f.email_field :email, value: @user.email, autofocus: true, autocomplete: "email", class: "form-control" %>
-    </div>
 
-    <div class="field mb-5">
-      <div class="label-container">
-        <%= f.label :new_password, class: "form-label" %>
-        <span class="minimum-length"><%= "（#{@minimum_password_length}文字以上）" if @minimum_password_length %></span>
+      <div class="field mb-5">
+        <div class="label-container">
+          <%= f.label :new_password, class: "form-label" %>
+          <span class="minimum-length"><%= "（#{@minimum_password_length}文字以上）" if @minimum_password_length %></span>
+        </div>
+        <%= f.password_field :password, autocomplete: "new-password", class: "form-control" %>
       </div>
-      <%= f.password_field :password, autocomplete: "new-password", class: "form-control" %>
-    </div>
 
-    <div class="field mb-5">
-      <div class="label-container">
-        <%= f.label :new_password_confirmation, class: "form-label" %>
+      <div class="field mb-5">
+        <div class="label-container">
+          <%= f.label :new_password_confirmation, class: "form-label" %>
+        </div>
+        <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control" %>
       </div>
-      <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control" %>
-    </div>
 
-    <hr class="edit-account-border">
+      <hr class="edit-account-border">
 
-    <div class="field mb-5">
-      <div class="label-container">
-        <%= f.label :current_password, class: "form-label" %>
-        <span class="required-mark">必須</span>
+      <div class="field mb-5">
+        <div class="label-container">
+          <%= f.label :current_password, class: "form-label" %>
+          <span class="required-mark">必須</span>
+        </div>
+        <%= f.password_field :current_password, autocomplete: "current-password", class: "form-control" %>
       </div>
-      <%= f.password_field :current_password, autocomplete: "current-password", class: "form-control" %>
-    </div>
 
-    <%= hidden_field_tag :form_type, 'account_edit' %>
+      <%= hidden_field_tag :form_type, 'account_edit' %>
 
-    <div class="actions mb-3 pt-4 d-grid mx-auto">
-      <%= f.submit "更新", class: "btn" %>
-    </div>
-  <% end %>
+      <div class="actions mb-3 pt-4 d-grid mx-auto">
+        <%= f.submit "更新", class: "btn" %>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,46 +1,48 @@
-<div class="container">
-  <h2 class="form-title">ログイン</h2>
+<div class="container mt-80">
+  <div class="responsive-container">
+    <h2 class="form-title">ログイン</h2>
 
-  <%= form_with model: @user, url: user_session_path, local: true do |f| %>
-    <div class="field mb-5">
-      <div class="label-container">
-        <%= f.label :email, class: "form-label" %>
+    <%= form_with model: @user, url: user_session_path, local: true do |f| %>
+      <div class="field mb-5">
+        <div class="label-container">
+          <%= f.label :email, class: "form-label" %>
+        </div>
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>
       </div>
-      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>
-    </div>
 
-    <div class="field mb-1">
-      <div class="label-container">
-        <%= f.label :password, class: "form-label" %>
+      <div class="field mb-1">
+        <div class="label-container">
+          <%= f.label :password, class: "form-label" %>
+        </div>
+        <%= f.password_field :password, autocomplete: "current-password", class: "form-control" %>
       </div>
-      <%= f.password_field :password, autocomplete: "current-password", class: "form-control" %>
-    </div>
 
-    <% if devise_mapping.rememberable? %>
-      <div class="field mb-5 d-flex align-items-center">
-        <%= f.check_box :remember_me %>
-        <%= f.label :remember_me, class: "fs-5 ms-2" %>
+      <% if devise_mapping.rememberable? %>
+        <div class="field mb-5 d-flex align-items-center">
+          <%= f.check_box :remember_me %>
+          <%= f.label :remember_me, class: "fs-5 ms-2" %>
+        </div>
+      <% end %>
+
+      <div class="actions mb-3 pt-4 d-grid mx-auto">
+        <%= f.submit "ログイン", class: "btn" %>
       </div>
     <% end %>
 
-    <div class="actions mb-3 pt-4 d-grid mx-auto">
-      <%= f.submit "ログイン", class: "btn" %>
+    <div class="forget-password-link">
+      <%= link_to "パスワードをお忘れの方はこちら", new_user_password_path %>
     </div>
-  <% end %>
-
-  <div class="forget-password-link">
-    <%= link_to "パスワードをお忘れの方はこちら", new_user_password_path %>
-  </div>
-  <div class="no-account-container">
-    <hr>
-    <h3 class="no-account-title">アカウントをお持ちでない方</h3>
-    <div class="guest-user-btn d-grid mx-auto mb-5">
-      <h4>ゲストユーザーとしてログインする</h4>
-      <%= link_to "ゲストログイン", users_guest_sign_in_path, method: :post, class: "btn" %>
-    </div>
-    <div class="registration-btn d-grid mx-auto pt-4">
-      <h4>新しくアカウントを作成する</h4>
-      <%= link_to "新規登録ページへ", new_user_registration_path, class: "btn" %>
+    <div class="no-account-container">
+      <hr>
+      <h3 class="no-account-title">アカウントをお持ちでない方</h3>
+      <div class="guest-user-btn d-grid mx-auto mb-5">
+        <h4>ゲストユーザーとしてログインする</h4>
+        <%= link_to "ゲストログイン", users_guest_sign_in_path, method: :post, class: "btn" %>
+      </div>
+      <div class="registration-btn d-grid mx-auto pt-4">
+        <h4>新しくアカウントを作成する</h4>
+        <%= link_to "新規登録ページへ", new_user_registration_path, class: "btn" %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/gadgets/edit.html.erb
+++ b/app/views/gadgets/edit.html.erb
@@ -1,52 +1,54 @@
-<div class="container">
-  <h2 class="form-title">ガジェットを編集</h2>
+<div class="container mt-80">
+  <div class="responsive-container">
+    <h2 class="form-title">ガジェットを編集</h2>
 
-  <%= form_with model: @gadget, url: gadget_path, local: true do |f| %>
-    <div class="field mb-5">
-      <div class="label-container">
-        <%= f.label :name, "ガジェット名", class: "form-label" %>
+    <%= form_with model: @gadget, url: gadget_path, local: true do |f| %>
+      <div class="field mb-5">
+        <div class="label-container">
+          <%= f.label :name, "ガジェット名", class: "form-label" %>
+        </div>
+        <%= f.text_field :name, autofocus: true, class: "form-control" %>
       </div>
-      <%= f.text_field :name, autofocus: true, class: "form-control" %>
-    </div>
-    <div class="field mb-5">
-      <div class="label-container">
-        <%= f.label :category, class: "form-label" %>
+      <div class="field mb-5">
+        <div class="label-container">
+          <%= f.label :category, class: "form-label" %>
+        </div>
+        <%= f.text_field :category, class: "form-control" %>
       </div>
-      <%= f.text_field :category, class: "form-control" %>
-    </div>
-    <div class="field mb-5">
-      <div class="label-container">
-        <%= f.label :image, "ガジェット画像", class: "form-label" %>
+      <div class="field mb-5">
+        <div class="label-container">
+          <%= f.label :image, "ガジェット画像", class: "form-label" %>
+        </div>
+        <%= f.file_field :image, class: "form-control", accept: 'image/jpeg, image/jpg, image/png, image/bmp' %>
       </div>
-      <%= f.file_field :image, class: "form-control", accept: 'image/jpeg, image/jpg, image/png, image/bmp' %>
-    </div>
-    <div class="field mb-5">
-      <div class="label-container">
-        <%= f.label :start_date, class: "form-label" %>
+      <div class="field mb-5">
+        <div class="label-container">
+          <%= f.label :start_date, class: "form-label" %>
+        </div>
+        <%= f.date_field :start_date, class: "form-control" %>
       </div>
-      <%= f.date_field :start_date, class: "form-control" %>
-    </div>
-    <div class="field mb-5">
-      <div class="label-container">
-        <%= f.label :point, class: "form-label" %>
+      <div class="field mb-5">
+        <div class="label-container">
+          <%= f.label :point, class: "form-label" %>
+        </div>
+        <%= f.text_area :point, class: "form-control", rows: 8 %>
       </div>
-      <%= f.text_area :point, class: "form-control", rows: 8 %>
-    </div>
-    <div class="field mb-5">
-      <div class="label-container">
-        <%= f.label :reason, class: "form-label" %>
+      <div class="field mb-5">
+        <div class="label-container">
+          <%= f.label :reason, class: "form-label" %>
+        </div>
+        <%= f.text_area :reason, class: "form-control", rows: 8 %>
       </div>
-      <%= f.text_area :reason, class: "form-control", rows: 8 %>
-    </div>
-    <div class="field mb-5">
-      <div class="label-container">
-        <%= f.label :usage, class: "form-label" %>
+      <div class="field mb-5">
+        <div class="label-container">
+          <%= f.label :usage, class: "form-label" %>
+        </div>
+        <%= f.text_area :usage, class: "form-control", rows: 8 %>
       </div>
-      <%= f.text_area :usage, class: "form-control", rows: 8 %>
-    </div>
 
-    <div class="actions mb-3 pt-4 d-grid mx-auto">
-      <%= f.submit "更新", class: "btn" %>
-    </div>
-  <% end %>
+      <div class="actions mb-3 pt-4 d-grid mx-auto">
+        <%= f.submit "更新", class: "btn" %>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/app/views/gadgets/new.html.erb
+++ b/app/views/gadgets/new.html.erb
@@ -1,55 +1,57 @@
-<div class="container">
-  <h2 class="form-title">ガジェットを登録</h2>
+<div class="container mt-80">
+  <div class="responsive-container">
+    <h2 class="form-title">ガジェットを登録</h2>
 
-  <%= form_with model: @gadget, url: gadgets_path, local: true do |f| %>
-    <div class="field mb-5">
-      <div class="label-container">
-        <%= f.label :name, "ガジェット名", class: "form-label" %>
-        <span class="required-mark">必須</span>
+    <%= form_with model: @gadget, url: gadgets_path, local: true do |f| %>
+      <div class="field mb-5">
+        <div class="label-container">
+          <%= f.label :name, "ガジェット名", class: "form-label" %>
+          <span class="required-mark">必須</span>
+        </div>
+        <%= f.text_field :name, autofocus: true, class: "form-control" %>
       </div>
-      <%= f.text_field :name, autofocus: true, class: "form-control" %>
-    </div>
-    <div class="field mb-5">
-      <div class="label-container">
-        <%= f.label :category, class: "form-label" %>
-        <span class="required-mark">必須</span>
+      <div class="field mb-5">
+        <div class="label-container">
+          <%= f.label :category, class: "form-label" %>
+          <span class="required-mark">必須</span>
+        </div>
+        <%= f.text_field :category, class: "form-control" %>
       </div>
-      <%= f.text_field :category, class: "form-control" %>
-    </div>
-    <div class="field mb-5">
-      <div class="label-container">
-        <%= f.label :image, "ガジェット画像", class: "form-label" %>
+      <div class="field mb-5">
+        <div class="label-container">
+          <%= f.label :image, "ガジェット画像", class: "form-label" %>
+        </div>
+        <%= f.file_field :image, class: "form-control", accept: 'image/jpeg, image/jpg, image/png, image/bmp' %>
       </div>
-      <%= f.file_field :image, class: "form-control", accept: 'image/jpeg, image/jpg, image/png, image/bmp' %>
-    </div>
-    <div class="field mb-5">
-      <div class="label-container">
-        <%= f.label :start_date, class: "form-label" %>
+      <div class="field mb-5">
+        <div class="label-container">
+          <%= f.label :start_date, class: "form-label" %>
+        </div>
+        <%= f.date_field :start_date, class: "form-control" %>
       </div>
-      <%= f.date_field :start_date, class: "form-control" %>
-    </div>
-    <div class="field mb-5">
-      <div class="label-container">
-        <%= f.label :point, class: "form-label" %>
-        <span class="required-mark">必須</span>
+      <div class="field mb-5">
+        <div class="label-container">
+          <%= f.label :point, class: "form-label" %>
+          <span class="required-mark">必須</span>
+        </div>
+        <%= f.text_area :point, class: "form-control", rows: 8 %>
       </div>
-      <%= f.text_area :point, class: "form-control", rows: 8 %>
-    </div>
-    <div class="field mb-5">
-      <div class="label-container">
-        <%= f.label :reason, class: "form-label" %>
+      <div class="field mb-5">
+        <div class="label-container">
+          <%= f.label :reason, class: "form-label" %>
+        </div>
+        <%= f.text_area :reason, class: "form-control", rows: 8 %>
       </div>
-      <%= f.text_area :reason, class: "form-control", rows: 8 %>
-    </div>
-    <div class="field mb-5">
-      <div class="label-container">
-        <%= f.label :usage, class: "form-label" %>
+      <div class="field mb-5">
+        <div class="label-container">
+          <%= f.label :usage, class: "form-label" %>
+        </div>
+        <%= f.text_area :usage, class: "form-control", rows: 8 %>
       </div>
-      <%= f.text_area :usage, class: "form-control", rows: 8 %>
-    </div>
 
-    <div class="actions mb-3 pt-4 d-grid mx-auto">
-      <%= f.submit "登録", class: "btn" %>
-    </div>
-  <% end %>
+      <div class="actions mb-3 pt-4 d-grid mx-auto">
+        <%= f.submit "登録", class: "btn" %>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/app/views/users/account.html.erb
+++ b/app/views/users/account.html.erb
@@ -1,21 +1,23 @@
-<div class="container">
-  <h2 class="form-title">アカウント情報</h2>
+<div class="container mt-80">
+  <div class="responsive-container">
+    <h2 class="form-title">アカウント情報</h2>
 
-  <div class="account-info">
-    <h4>メールアドレス</h4>
-    <p><%= @user.email %></p>
-    <h4>パスワード</h4>
-    <p>●●●●●●●●</p>
-  </div>
+    <div class="account-info">
+      <h4>メールアドレス</h4>
+      <p><%= @user.email %></p>
+      <h4>パスワード</h4>
+      <p>●●●●●●●●</p>
+    </div>
 
-  <div class="actions mb-3 pt-4 d-grid mx-auto">
-    <%= link_to "編集", edit_user_registration_path, class: "btn d-flex align-items-center justify-content-center" %>
-  </div>
+    <div class="actions mb-3 pt-4 d-grid mx-auto">
+      <%= link_to "編集", edit_user_registration_path, class: "btn d-flex align-items-center justify-content-center" %>
+    </div>
 
-  <div class="text-center mt-64">
-    <button type="button" class="text-info border-0 bg-light fs-2 fw-bold" data-bs-toggle="modal" data-bs-target="#deleteAccountModal">
-      アカウントを削除する
-    </button>
+    <div class="text-center mt-64">
+      <button type="button" class="text-info border-0 bg-light fs-2 fw-bold" data-bs-toggle="modal" data-bs-target="#deleteAccountModal">
+        アカウントを削除する
+      </button>
+    </div>
   </div>
 </div>
 

--- a/app/views/users/edit_profile.html.erb
+++ b/app/views/users/edit_profile.html.erb
@@ -1,32 +1,34 @@
-<div class="container">
-  <h2 class="form-title">プロフィール編集</h2>
+<div class="container mt-80">
+  <div class="responsive-container">
+    <h2 class="form-title">プロフィール編集</h2>
 
-  <%= form_with model: @user, url: user_registration_path, method: :patch, local: true do |f| %>
-    <div class="field mb-5">
-      <div class="label-container">
-        <%= f.label :name, "ユーザー名", class: "form-label" %>
+    <%= form_with model: @user, url: user_registration_path, method: :patch, local: true do |f| %>
+      <div class="field mb-5">
+        <div class="label-container">
+          <%= f.label :name, "ユーザー名", class: "form-label" %>
+        </div>
+        <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "form-control" %>
       </div>
-      <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "form-control" %>
-    </div>
 
-    <div class="field mb-5">
-      <div class="label-container">
-        <%= f.label :avatar, "プロフィール画像", class: "form-label" %>
+      <div class="field mb-5">
+        <div class="label-container">
+          <%= f.label :avatar, "プロフィール画像", class: "form-label" %>
+        </div>
+        <%= f.file_field :avatar, accept: 'image/jpeg, image/jpg, image/png, image/bmp', class: "form-control" %>
       </div>
-      <%= f.file_field :avatar, accept: 'image/jpeg, image/jpg, image/png, image/bmp', class: "form-control" %>
-    </div>
 
-    <div class="field mb-5">
-      <div class="label-container">
-        <%= f.label :introduction, "自己紹介", class: "form-label" %>
+      <div class="field mb-5">
+        <div class="label-container">
+          <%= f.label :introduction, "自己紹介", class: "form-label" %>
+        </div>
+        <%= f.text_area :introduction, autocomplete: "introduction", class: "form-control", rows: 5 %>
       </div>
-      <%= f.text_area :introduction, autocomplete: "introduction", class: "form-control", rows: 5 %>
-    </div>
 
-    <%= hidden_field_tag :form_type, 'profile_edit' %>
+      <%= hidden_field_tag :form_type, 'profile_edit' %>
 
-    <div class="actions mb-3 pt-4 d-grid mx-auto">
-      <%= f.submit "更新", class: "btn" %>
-    </div>
-  <% end %>
+      <div class="actions mb-3 pt-4 d-grid mx-auto">
+        <%= f.submit "更新", class: "btn" %>
+      </div>
+    <% end %>
+  </div>
 </div>


### PR DESCRIPTION
【実装機能概要】

- 以下ページの画面幅768px以上の場合コンテンツ幅720pxに固定するように修正
  - ログインページ
  - パスワード再設定ページ
  - ガジェット編集ページ
  - プロフィール編集ページ
  - アカウント情報ページ
  - アカウント情報編集ページ
  - ガジェット登録ページ