### PR TITLE
ガジェット詳細／コメント一覧ページのレスポンシブ対応 #116#117

### DIFF
--- a/app/assets/stylesheets/components/_parts.scss
+++ b/app/assets/stylesheets/components/_parts.scss
@@ -214,8 +214,13 @@
 // 画面幅768px以上の場合
 @media screen and (min-width:768px) {
 
-  .responsive-container {
+  .responsive-container-540 {
     max-width: 540px;
+    margin: 0 auto;
+  }
+
+  .responsive-container-720 {
+    max-width: 720px;
     margin: 0 auto;
   }
 }

--- a/app/assets/stylesheets/gadgets/_show.scss
+++ b/app/assets/stylesheets/gadgets/_show.scss
@@ -1,12 +1,11 @@
-// @import "components/parts";
-// @import "components/buttons";
-
 .gadget-image-lg {
   margin: 12px 0;
 
   img {
     width: 100%;
-    height: 50vw;
+    // height: 50vw;
+    height: 100%;
+    // max-height: 580px;
   }
 }
 

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -1,101 +1,103 @@
-<div class="container">
-  <p id="notice"><%= notice %></p>
+<div class="container mt-5">
+  <div class="responsive-container-720">
+    <p id="notice"><%= notice %></p>
 
-  <div>
-    <div class="d-flex justify-content-between align-items-center">
-      <%= link_to mygadgets_user_path(@gadget.user.id) do %>
-        <div class="info-container">
-          <div class="icon-image-md">
-            <%= user_avatar_image_tag(@gadget.user) %>
+    <div>
+      <div class="d-flex justify-content-between align-items-center">
+        <%= link_to mygadgets_user_path(@gadget.user.id) do %>
+          <div class="info-container">
+            <div class="icon-image-md">
+              <%= user_avatar_image_tag(@gadget.user) %>
+            </div>
+            <div class="user-name-and-creationdate-md">
+              <p class="user-name-md"><%= @gadget.user.name %></p>
+              <p class="creationdate-md"><%= @gadget.created_at.to_s(:default) %></p>
+            </div>
           </div>
-          <div class="user-name-and-creationdate-md">
-            <p class="user-name-md"><%= @gadget.user.name %></p>
-            <p class="creationdate-md"><%= @gadget.created_at.to_s(:default) %></p>
+        <% end %>
+        <% if user_signed_in? %>
+          <div id="follow-form-<%= @gadget.user.id %>">
+            <%= render 'shared/follow-and-unfollow', user: @gadget.user %>
           </div>
-        </div>
-      <% end %>
-      <% if user_signed_in? %>
-        <div id="follow-form-<%= @gadget.user.id %>">
-          <%= render 'shared/follow-and-unfollow', user: @gadget.user %>
-        </div>
-      <% end %>
-    </div>
-  </div>
-
-  <button class="btn mt-4 ps-0" type="button" data-bs-toggle="collapse" data-bs-target="#gadgetDetails" aria-expanded="false" aria-controls="gadgetDetails">
-    <span class="collapse-text fs-5 ">▲ ガジェット詳細を見る</span>
-  </button>
-  <div class="gadget-details-container collapse mt-0 mb-5" id="gadgetDetails">
-    <div class="gadget-detail">
-      <p class="category">ガジェット名</p>
-      <p class="content"><%= @gadget.name %></p>
-    </div>
-    <div class="gadget-detail">
-      <p class="category">カテゴリー</p>
-      <P class="content"><%= @gadget.category %></P>
-    </div>
-    <div class="gadget-detail">
-      <p class="category">使用開始日</p>
-      <P class="content"><%= @gadget.start_date %></P>
-    </div>
-    <div class="gadget-detail">
-      <p class="category">推しポイント</p>
-      <P class="content"><%= safe_join(@gadget.point.split("\n"),tag(:br)) %></P>
-    </div>
-    <div class="gadget-detail">
-      <p class="category">使用用途</p>
-      <P class="content"><%= safe_join(@gadget.usage.split("\n"),tag(:br)) %></P>
-    </div>
-    <div class="gadget-detail">
-      <p class="category">選んだ理由</p>
-      <P class="content"><%= safe_join(@gadget.reason.split("\n"),tag(:br)) %></P>
-    </div>
-    <div class="detail-link-container">
-      <%= link_to "＞ ガジェット詳細へ", gadget_path(@gadget), class: "btn detail-link" %>
-    </div>
-  </div>
-
-  <div class="comments-container mt-5">
-    <div class="comments-title justify-content-between d-flex align-items-center border-start border-dark border-5 ps-1 mb-4">
-      <div class="d-flex align-items-center">
-        <h4 class="mb-0 fs-2">コメント</h4>
-        <P class="ms-3 fs-5">全<%= @gadget.comments.count %>件</P>
+        <% end %>
       </div>
     </div>
-    <div class="comments">
-      <% @gadget.comments.each do |comment| %>
-        <div class="comment mb-4">
-          <div class="d-flex justify-content-between mb-2">
-            <div class="d-flex align-items-center">
-              <div class="icon-image-sm">
-                <%= user_avatar_image_tag(comment.user) %>
+
+    <button class="btn mt-4 ps-0" type="button" data-bs-toggle="collapse" data-bs-target="#gadgetDetails" aria-expanded="false" aria-controls="gadgetDetails">
+      <span class="collapse-text fs-5 ">▲ ガジェット詳細を見る</span>
+    </button>
+    <div class="gadget-details-container collapse mt-0 mb-5" id="gadgetDetails">
+      <div class="gadget-detail">
+        <p class="category">ガジェット名</p>
+        <p class="content"><%= @gadget.name %></p>
+      </div>
+      <div class="gadget-detail">
+        <p class="category">カテゴリー</p>
+        <P class="content"><%= @gadget.category %></P>
+      </div>
+      <div class="gadget-detail">
+        <p class="category">使用開始日</p>
+        <P class="content"><%= @gadget.start_date %></P>
+      </div>
+      <div class="gadget-detail">
+        <p class="category">推しポイント</p>
+        <P class="content"><%= safe_join(@gadget.point.split("\n"),tag(:br)) %></P>
+      </div>
+      <div class="gadget-detail">
+        <p class="category">使用用途</p>
+        <P class="content"><%= safe_join(@gadget.usage.split("\n"),tag(:br)) %></P>
+      </div>
+      <div class="gadget-detail">
+        <p class="category">選んだ理由</p>
+        <P class="content"><%= safe_join(@gadget.reason.split("\n"),tag(:br)) %></P>
+      </div>
+      <div class="detail-link-container">
+        <%= link_to "＞ ガジェット詳細へ", gadget_path(@gadget), class: "btn detail-link" %>
+      </div>
+    </div>
+
+    <div class="comments-container mt-5">
+      <div class="comments-title justify-content-between d-flex align-items-center border-start border-dark border-5 ps-1 mb-4">
+        <div class="d-flex align-items-center">
+          <h4 class="mb-0 fs-2">コメント</h4>
+          <P class="ms-3 fs-5">全<%= @gadget.comments.count %>件</P>
+        </div>
+      </div>
+      <div class="comments">
+        <% @gadget.comments.each do |comment| %>
+          <div class="comment mb-4">
+            <div class="d-flex justify-content-between mb-2">
+              <div class="d-flex align-items-center">
+                <div class="icon-image-sm">
+                  <%= user_avatar_image_tag(comment.user) %>
+                </div>
+                <div class="user-name-and-creationdate-sm">
+                  <p class="user-name-sm"><%= comment.user.name %></p>
+                  <p class="creationdate-sm"><%= comment.created_at.to_s(:default) %></p>
+                </div>
               </div>
-              <div class="user-name-and-creationdate-sm">
-                <p class="user-name-sm"><%= comment.user.name %></p>
-                <p class="creationdate-sm"><%= comment.created_at.to_s(:default) %></p>
+              <div class="d-flex align-items-end">
+                <% if comment.user == current_user %>
+                  <%= link_to "削除", [comment.gadget, comment], method: :delete, data: { confirm: "本当に削除しますか？" } %>
+                <% end %>
               </div>
             </div>
-            <div class="d-flex align-items-end">
-              <% if comment.user == current_user %>
-                <%= link_to "削除", [comment.gadget, comment], method: :delete, data: { confirm: "本当に削除しますか？" } %>
-              <% end %>
+            <P class="ps-2 fs-5"><%= comment.content %></P>
+          </div>
+        <% end %>
+      </div>
+      <% if user_signed_in? %>
+        <%= form_with(model: [ @gadget, @gadget.comments.build ], local: true) do |form| %>
+          <div class="row mt-5">
+            <div class="col-10">
+              <%= form.text_area :content, rows: 1, class: "form-control h-100" %>
+            </div>
+            <div class="col-2 d-flex align-items-center">
+              <%= form.submit "送信", class: "btn btn-secondary text-light fw-bold fs-5 h-100" %>
             </div>
           </div>
-          <P class="ps-2 fs-5"><%= comment.content %></P>
-        </div>
+        <% end %>
       <% end %>
     </div>
-    <% if user_signed_in? %>
-      <%= form_with(model: [ @gadget, @gadget.comments.build ], local: true) do |form| %>
-        <div class="row mt-5">
-          <div class="col-10">
-            <%= form.text_area :content, rows: 1, class: "form-control h-100" %>
-          </div>
-          <div class="col-2 d-flex align-items-center">
-            <%= form.submit "送信", class: "btn btn-secondary text-light fw-bold fs-5 h-100" %>
-          </div>
-        </div>
-      <% end %>
-    <% end %>
   </div>
 </div>

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -14,9 +14,11 @@
           </div>
         </div>
       <% end %>
-      <div id="follow-form-<%= @gadget.user.id %>">
-        <%= render 'shared/follow-and-unfollow', user: @gadget.user %>
-      </div>
+      <% if user_signed_in? %>
+        <div id="follow-form-<%= @gadget.user.id %>">
+          <%= render 'shared/follow-and-unfollow', user: @gadget.user %>
+        </div>
+      <% end %>
     </div>
   </div>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,5 +1,5 @@
 <div class="container mt-80">
-  <div class="responsive-container">
+  <div class="responsive-container-540">
     <h2 class="form-title mb-3">パスワード再設定</h2>
     <p class="form-title-description">ご登録のメールアドレス宛に再設定用のURLをお送りいたします。</p>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="container mt-80">
-  <div class="responsive-container">
+  <div class="responsive-container-540">
     <h2 class="form-title">アカウント情報を編集</h2>
 
     <%= form_with model: @user, url: user_registration_path, local: true do |f| %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,5 +1,5 @@
 <div class="container mt-80">
-  <div class="responsive-container">
+  <div class="responsive-container-540">
     <h2 class="form-title">ユーザー新規登録</h2>
 
     <%= form_with model: @user, url: user_registration_path, local: true do |f| %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,5 +1,5 @@
 <div class="container mt-80">
-  <div class="responsive-container">
+  <div class="responsive-container-540">
     <h2 class="form-title">ログイン</h2>
 
     <%= form_with model: @user, url: user_session_path, local: true do |f| %>

--- a/app/views/gadgets/edit.html.erb
+++ b/app/views/gadgets/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="container mt-80">
-  <div class="responsive-container">
+  <div class="responsive-container-540">
     <h2 class="form-title">ガジェットを編集</h2>
 
     <%= form_with model: @gadget, url: gadget_path, local: true do |f| %>

--- a/app/views/gadgets/liked_users.html.erb
+++ b/app/views/gadgets/liked_users.html.erb
@@ -16,9 +16,11 @@
               </div>
             </div>
           <% end %>
-          <div id="follow-form-<%= user.id %>">
-            <%= render 'shared/follow-and-unfollow', user: user %>
-          </div>
+          <% if user_signed_in? %>
+            <div id="follow-form-<%= user.id %>">
+              <%= render 'shared/follow-and-unfollow', user: user %>
+            </div>
+          <% end %>
         </div>
         <div class="user-introduction">
           <p><%= user.introduction %></p>

--- a/app/views/gadgets/new.html.erb
+++ b/app/views/gadgets/new.html.erb
@@ -1,5 +1,5 @@
 <div class="container mt-80">
-  <div class="responsive-container">
+  <div class="responsive-container-540">
     <h2 class="form-title">ガジェットを登録</h2>
 
     <%= form_with model: @gadget, url: gadgets_path, local: true do |f| %>

--- a/app/views/gadgets/show.html.erb
+++ b/app/views/gadgets/show.html.erb
@@ -1,7 +1,7 @@
-<div class="container">
-  <p id="notice"><%= notice %></p>
+<div class="container mt-5">
+  <div class="responsive-container-720">
+    <p id="notice"><%= notice %></p>
 
-  <div>
     <div class="d-flex justify-content-between align-items-center">
       <%= link_to mygadgets_user_path(@gadget.user.id) do %>
         <div class="info-container">
@@ -14,99 +14,100 @@
           </div>
         </div>
       <% end %>
-      <div id="follow-form-<%= @gadget.user.id %>">
-        <%= render 'shared/follow-and-unfollow', user: @gadget.user %>
+      <% if user_signed_in? %>
+        <div id="follow-form-<%= @gadget.user.id %>">
+          <%= render 'shared/follow-and-unfollow', user: @gadget.user %>
+        </div>
+      <% end %>
+    </div>
+
+    <div class="gadget-image-lg">
+      <%= image_tag @gadget.image %>
+    </div>
+
+    <%# いいね %>
+    <div class="likes-and-comments" id="likes-and-comments-<%= @gadget.id %>">
+      <%= render partial: 'shared/likes_and_liked_users', locals: {gadget: @gadget} %>
+    </div>
+
+    <div class="gadget-details-container">
+      <div class="gadget-detail">
+        <p class="category">ガジェット名</p>
+        <p class="content"><%= @gadget.name %></p>
+      </div>
+      <div class="gadget-detail">
+        <p class="category">カテゴリー</p>
+        <P class="content"><%= @gadget.category %></P>
+      </div>
+      <div class="gadget-detail">
+        <p class="category">使用開始日</p>
+        <P class="content"><%= @gadget.start_date %></P>
+      </div>
+      <div class="gadget-detail">
+        <p class="category">推しポイント</p>
+        <P class="content"><%= safe_join(@gadget.point.split("\n"),tag(:br)) %></P>
+      </div>
+      <div class="gadget-detail">
+        <p class="category">使用用途</p>
+        <P class="content"><%= safe_join(@gadget.usage.split("\n"),tag(:br)) %></P>
+      </div>
+      <div class="gadget-detail">
+        <p class="category">選んだ理由</p>
+        <P class="content"><%= safe_join(@gadget.reason.split("\n"),tag(:br)) %></P>
       </div>
     </div>
-  </div>
 
-  <div class="gadget-image-lg">
-    <%= image_tag @gadget.image %>
-  </div>
+    <div class="edit-btn-container">
+      <%= link_to '編集する', edit_gadget_path(@gadget), class: "btn edit-btn" %>
+    </div>
 
-  <%# いいね %>
-  <div class="likes-and-comments" id="likes-and-comments-<%= @gadget.id %>">
-    <%= render partial: 'shared/likes_and_liked_users', locals: {gadget: @gadget} %>
-  </div>
-
-  <div class="gadget-details-container">
-    <div class="gadget-detail">
-      <p class="category">ガジェット名</p>
-      <p class="content"><%= @gadget.name %></p>
-    </div>
-    <div class="gadget-detail">
-      <p class="category">カテゴリー</p>
-      <P class="content"><%= @gadget.category %></P>
-    </div>
-    <div class="gadget-detail">
-      <p class="category">使用開始日</p>
-      <P class="content"><%= @gadget.start_date %></P>
-    </div>
-    <div class="gadget-detail">
-      <p class="category">推しポイント</p>
-      <P class="content"><%= safe_join(@gadget.point.split("\n"),tag(:br)) %></P>
-    </div>
-    <div class="gadget-detail">
-      <p class="category">使用用途</p>
-      <P class="content"><%= safe_join(@gadget.usage.split("\n"),tag(:br)) %></P>
-    </div>
-    <div class="gadget-detail">
-      <p class="category">選んだ理由</p>
-      <P class="content"><%= safe_join(@gadget.reason.split("\n"),tag(:br)) %></P>
-    </div>
-  </div>
-
-  <div class="edit-btn-container">
-    <%= link_to '編集する', edit_gadget_path(@gadget), class: "btn edit-btn" %>
-  </div>
-
-  <div class="comments-container">
-    <div class="comments-title justify-content-between d-flex align-items-center border-start border-dark border-5 ps-1 mb-4">
-      <div class="d-flex align-items-center">
-        <h4 class="mb-0 fs-2">コメント</h4>
-        <P class="ms-3 fs-5">全<%= @gadget.comments.count %>件</P>
+    <div class="comments-container">
+      <div class="comments-title justify-content-between d-flex align-items-center border-start border-dark border-5 ps-1 mb-4">
+        <div class="d-flex align-items-center">
+          <h4 class="mb-0 fs-2">コメント</h4>
+          <P class="ms-3 fs-5">全<%= @gadget.comments.count %>件</P>
+        </div>
+        <div>
+          <% if @gadget.comments.count >= 6 %>
+            <%= link_to "コメントを全て見る", gadget_comments_path(@gadget.id), class: "fs-5 text-secondary" %>
+          <% end %>
+        </div>
       </div>
-      <div>
-        <% if @gadget.comments.count >= 6 %>
-          <%= link_to "コメントを全て見る", gadget_comments_path(@gadget.id), class: "fs-5 text-secondary" %>
+      <div class="comments">
+        <% @gadget.comments.each do |comment| %>
+          <div class="comment mb-4">
+            <div class="d-flex justify-content-between mb-2">
+              <div class="d-flex align-items-center">
+                <div class="icon-image-sm">
+                  <%= user_avatar_image_tag(comment.user) %>
+                </div>
+                <div class="user-name-and-creationdate-sm">
+                  <p class="user-name-sm"><%= comment.user.name %></p>
+                  <p class="creationdate-sm"><%= comment.created_at.to_s(:default) %></p>
+                </div>
+              </div>
+              <div class="d-flex align-items-end">
+                <% if comment.user == current_user %>
+                  <%= link_to "削除", [comment.gadget, comment], method: :delete, data: { confirm: "本当に削除しますか？" } %>
+                <% end %>
+              </div>
+            </div>
+            <P class="ps-2 fs-5"><%= comment.content %></P>
+          </div>
         <% end %>
       </div>
-    </div>
-    <div class="comments">
-      <% @gadget.comments.each do |comment| %>
-        <div class="comment mb-4">
-          <div class="d-flex justify-content-between mb-2">
-            <div class="d-flex align-items-center">
-              <div class="icon-image-sm">
-                <%= user_avatar_image_tag(comment.user) %>
-              </div>
-              <div class="user-name-and-creationdate-sm">
-                <p class="user-name-sm"><%= comment.user.name %></p>
-                <p class="creationdate-sm"><%= comment.created_at.to_s(:default) %></p>
-              </div>
+      <% if user_signed_in? %>
+        <%= form_with(model: [ @gadget, @gadget.comments.build ], local: true) do |form| %>
+          <div class="row mt-5">
+            <div class="col-10">
+              <%= form.text_area :content, rows: 1, class: "form-control h-100" %>
             </div>
-            <div class="d-flex align-items-end">
-              <% if comment.user == current_user %>
-                <%= link_to "削除", [comment.gadget, comment], method: :delete, data: { confirm: "本当に削除しますか？" } %>
-              <% end %>
+            <div class="col-2 d-flex align-items-center">
+              <%= form.submit "送信", class: "btn btn-secondary text-light fw-bold fs-5 h-100" %>
             </div>
           </div>
-          <P class="ps-2 fs-5"><%= comment.content %></P>
-        </div>
+        <% end %>
       <% end %>
     </div>
-    <% if user_signed_in? %>
-      <%= form_with(model: [ @gadget, @gadget.comments.build ], local: true) do |form| %>
-        <div class="row mt-5">
-          <div class="col-10">
-            <%= form.text_area :content, rows: 1, class: "form-control h-100" %>
-          </div>
-          <div class="col-2 d-flex align-items-center">
-            <%= form.submit "送信", class: "btn btn-secondary text-light fw-bold fs-5 h-100" %>
-          </div>
-        </div>
-      <% end %>
-    <% end %>
   </div>
-
 </div>

--- a/app/views/users/account.html.erb
+++ b/app/views/users/account.html.erb
@@ -1,5 +1,5 @@
 <div class="container mt-80">
-  <div class="responsive-container">
+  <div class="responsive-container-540">
     <h2 class="form-title">アカウント情報</h2>
 
     <div class="account-info">

--- a/app/views/users/edit_profile.html.erb
+++ b/app/views/users/edit_profile.html.erb
@@ -1,5 +1,5 @@
 <div class="container mt-80">
-  <div class="responsive-container">
+  <div class="responsive-container-540">
     <h2 class="form-title">プロフィール編集</h2>
 
     <%= form_with model: @user, url: user_registration_path, method: :patch, local: true do |f| %>

--- a/app/views/users/show_favorites.html.erb
+++ b/app/views/users/show_favorites.html.erb
@@ -9,9 +9,11 @@
         <%= link_to "プロフィールを編集", edit_profile_user_path(@user.id), class: "btn edit-profile-btn" %>
       </div>
     <% else %>
-      <div id="follow-form-<%= @user.id %>">
-        <%= render 'shared/follow-and-unfollow', user: @user %>
-      </div>
+      <% if user_signed_in? %>
+        <div id="follow-form-<%= @user.id %>">
+          <%= render 'shared/follow-and-unfollow', user: @user %>
+        </div>
+      <% end %>
     <% end %>
   </div>
   <div class="inroduction">

--- a/app/views/users/show_mygadgets.html.erb
+++ b/app/views/users/show_mygadgets.html.erb
@@ -9,9 +9,11 @@
         <%= link_to "プロフィールを編集", edit_profile_user_path(@user.id), class: "btn edit-profile-btn" %>
       </div>
     <% else %>
-      <div id="follow-form-<%= @user.id %>">
-        <%= render 'shared/follow-and-unfollow', user: @user %>
-      </div>
+      <% if user_signed_in? %>
+        <div id="follow-form-<%= @user.id %>">
+          <%= render 'shared/follow-and-unfollow', user: @user %>
+        </div>
+      <% end %>
     <% end %>
   </div>
   <div class="inroduction">


### PR DESCRIPTION
#116 #117 
【実装機能概要】

- ガジェット詳細ページのレスポンシブ対応
- 各formのページのViewのclass:responsive-containerをclass:responsive-container-540に変更
  - 新規登録ページ
  - ログインページ
  - パスワード再発行ページ
  - ガジェット編集ページ
  - ガジェット登録ページ
  - アカウント情報ページ
  - アカウント情報編集ページ
  - プロフィール編集ページ
- フォローボタンを表示している全ページのViewにログインしている場合のみ表示というif文の制限をかける
  - ガジェット詳細ページ
  - コメント一覧ページ
  - いいねしたユーザー一覧ページ
  - マイページ（Myガジェット）
  - マイページ（お気に入り）
- コメント一覧ページのレスポンシブ対応