### PR TITLE
他ユーザーのガジェットを編集できないように制限 #151

### DIFF
--- a/app/controllers/gadgets_controller.rb
+++ b/app/controllers/gadgets_controller.rb
@@ -1,6 +1,7 @@
 class GadgetsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destory]
   before_action :set_gadget, only: %i[ show edit update destroy ]
+  before_action :ensure_correct_user, only: [:edit, :update, :destroy]
 
   def top
     @gadgets = Gadget.all.order('created_at DESC').limit(10)
@@ -74,5 +75,12 @@ class GadgetsController < ApplicationController
     # Only allow a list of trusted parameters through.
     def gadget_params
       params.require(:gadget).permit(:user_id, :name, :start_date, :category, :reason, :point, :usage, :image).merge(user_id:current_user.id)
+    end
+
+    def ensure_correct_user
+      if @gadget.user_id != current_user.id
+        flash[:alert] = "権限がありません。"
+        redirect_to gadget_path
+      end
     end
 end

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -89,10 +89,10 @@
       <% if user_signed_in? %>
         <%= form_with(model: [ @gadget, @gadget.comments.build ], local: true) do |form| %>
           <div class="row mt-5">
-            <div class="col-10">
+            <div class="col-10 col-md-11">
               <%= form.text_area :content, rows: 1, class: "form-control h-100" %>
             </div>
-            <div class="col-2 d-flex align-items-center">
+            <div class="col-2 col-md-1 d-flex align-items-center">
               <%= form.submit "送信", class: "btn btn-secondary text-light fw-bold fs-5 h-100" %>
             </div>
           </div>

--- a/app/views/gadgets/edit.html.erb
+++ b/app/views/gadgets/edit.html.erb
@@ -45,10 +45,35 @@
         </div>
         <%= f.text_area :usage, class: "form-control", rows: 8 %>
       </div>
-
       <div class="actions mb-3 pt-4 d-grid mx-auto">
         <%= f.submit "更新", class: "btn" %>
       </div>
     <% end %>
+
+    <div class="text-center mt-56">
+      <button type="button" class="text-info border-0 bg-light fs-4" data-bs-toggle="modal" data-bs-target="#deleteGadgetModal">
+        ガジェットを削除する
+      </button>
+    </div>
+  </div>
+</div>
+
+<!-- Delete Gadget Modal -->
+<div class="modal fade" id="deleteGadgetModal" tabindex="-1" aria-labelledby="deleteGadgetModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body fs-4 fw-bold">
+        ガジェットを削除してよろしいですか？
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary fs-5" data-bs-dismiss="modal">キャンセル</button>
+        <%= form_with model: @gadget, url: gadget_path, method: :delete, local: true, class: "d-inline" do |f| %>
+          <%= f.submit "ガジェットを削除する", class: "btn btn-danger text-light fs-5" %>
+        <% end %>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/views/gadgets/show.html.erb
+++ b/app/views/gadgets/show.html.erb
@@ -57,9 +57,11 @@
       </div>
     </div>
 
-    <div class="edit-btn-container">
-      <%= link_to '編集する', edit_gadget_path(@gadget), class: "btn edit-btn" %>
-    </div>
+    <% if @gadget.user_id == current_user.id %>
+      <div class="edit-btn-container">
+        <%= link_to '編集する', edit_gadget_path(@gadget), class: "btn edit-btn" %>
+      </div>
+    <% end %>
 
     <div class="comments-container">
       <div class="comments-title justify-content-between d-flex align-items-center border-start border-dark border-5 ps-1 mb-4">
@@ -99,10 +101,10 @@
       <% if user_signed_in? %>
         <%= form_with(model: [ @gadget, @gadget.comments.build ], local: true) do |form| %>
           <div class="row mt-5">
-            <div class="col-10">
+            <div class="col-10 col-md-11">
               <%= form.text_area :content, rows: 1, class: "form-control h-100" %>
             </div>
-            <div class="col-2 d-flex align-items-center">
+            <div class="col-2 col-md-1 d-flex align-items-center">
               <%= form.submit "送信", class: "btn btn-secondary text-light fw-bold fs-5 h-100" %>
             </div>
           </div>

--- a/app/views/users/show_mygadgets.html.erb
+++ b/app/views/users/show_mygadgets.html.erb
@@ -39,9 +39,13 @@
       </div>
     </div>
 
-    <div class="mypage-link-lists">
-      <p class="current-page">My ガジェット</p>
-      <p class="link-page"><%= link_to "お気に入り", favorites_user_path(@user.id) %></p>
+    <div class="mypage-link-lists row justify-content-center">
+      <div class="col">
+        <p class="current-page text-center"><span>My ガジェット</span></p>
+      </div>
+      <div class="col">
+        <p class="link-page text-center"><%= link_to "お気に入り", favorites_user_path(@user.id) %></p>
+      </div>
     </div>
 
     <div class="mygadget-lists">


### PR DESCRIPTION
#151 
【実装機能概要】

- gadgetsコントローラーにてガジェットのユーザーとログインユーザーが一致しているか確認するメソッドを追加
- Viewにて、ガジェットのユーザーとログインユーザーが一致している場合のみ編集ボタンが表示されるように修正
- マイページ（Myガジェット）のレスポンシブ対応（修正漏れ分）
- ガジェット詳細／コメント一覧ページのコメント入力欄のレスポンシブ対応
- 登録したガジェットを削除するリンク（orボタン）を新規追加