### PR TITLE
ゲストユーザーのできる機能を制限 #147

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,11 @@ class User < ApplicationRecord
     end
   end
 
+  # ゲストユーザーかどうか判断するメソッド
+  def guest?
+    email == 'guest@example.com'
+  end
+
   # パスワードなしでユーザーが自分のアカウントを更新できるようにする
   def update_without_current_password(params, *options)
     params.delete(:current_password)

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,5 +1,11 @@
 <div class="container mt-80">
   <div class="responsive-container-540">
+    <% if current_user.guest? %>
+      <div class="alert bg-danger text-light fs-4 text-center my-5 p-2" role="alert">
+        <i class="fas fa-exclamation-triangle"></i>
+        ゲストユーザーのためアカウント情報の編集はできません
+      </div>
+    <% end %>
     <h2 class="form-title">アカウント情報を編集</h2>
 
     <%= form_with model: @user, url: user_registration_path, local: true do |f| %>
@@ -9,7 +15,7 @@
         <div class="label-container">
           <%= f.label :email, class: "form-label" %>
         </div>
-        <%= f.email_field :email, value: @user.email, autofocus: true, autocomplete: "email", class: "form-control" %>
+        <%= f.email_field :email, value: @user.email, autofocus: true, autocomplete: "email", class: "form-control", disabled: current_user.guest? %>
       </div>
 
       <div class="field mb-5">
@@ -17,14 +23,14 @@
           <%= f.label :new_password, class: "form-label" %>
           <span class="minimum-length"><%= "（#{@minimum_password_length}文字以上）" if @minimum_password_length %></span>
         </div>
-        <%= f.password_field :password, autocomplete: "new-password", class: "form-control" %>
+        <%= f.password_field :password, autocomplete: "new-password", class: "form-control", disabled: current_user.guest? %>
       </div>
 
       <div class="field mb-5">
         <div class="label-container">
           <%= f.label :new_password_confirmation, class: "form-label" %>
         </div>
-        <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control" %>
+        <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control", disabled: current_user.guest? %>
       </div>
 
       <hr class="edit-account-border">
@@ -34,13 +40,13 @@
           <%= f.label :current_password, class: "form-label" %>
           <span class="required-mark">必須</span>
         </div>
-        <%= f.password_field :current_password, autocomplete: "current-password", class: "form-control" %>
+        <%= f.password_field :current_password, autocomplete: "current-password", class: "form-control", disabled: current_user.guest? %>
       </div>
 
       <%= hidden_field_tag :form_type, 'account_edit' %>
 
       <div class="actions mb-3 pt-4 d-grid mx-auto">
-        <%= f.submit "更新", class: "btn" %>
+        <%= f.submit "更新", class: "btn", disabled: current_user.guest? %>
       </div>
     <% end %>
   </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -8,7 +8,7 @@
       <div class="field mb-5">
         <div class="label-container">
           <%= f.label :name, class: "form-label" %>
-          <span class="minimum-length"><%= "(#{User::MAX_USER_NAME_LENGTH}文字以上)" %></span>
+          <span class="minimum-length"><%= "(#{User::MAX_USER_NAME_LENGTH}文字以下)" %></span>
           <span class="required-mark">必須</span>
         </div>
         <%= f.text_field :name, autofocus: true, autocomplete: "username", class: "form-control" %>

--- a/app/views/gadgets/top.html.erb
+++ b/app/views/gadgets/top.html.erb
@@ -80,7 +80,7 @@
       <% end %>
     </div>
   </div>
-  <div class="list-link-container">
+  <div class="list-link-container mt-5">
     <%= link_to "新着投稿一覧はこちら", gadgets_path, class: "btn list-link" %>
   </div>
 </div>
@@ -138,7 +138,7 @@
       <% end %>
     </div>
   </div>
-  <div class="list-link-container">
+  <div class="list-link-container mt-5">
     <P><%= link_to "ユーザー一覧はこちら", users_path, class: "btn list-link" %></P>
   </div>
 </div>

--- a/app/views/users/edit_profile.html.erb
+++ b/app/views/users/edit_profile.html.erb
@@ -1,5 +1,11 @@
 <div class="container mt-80">
   <div class="responsive-container-540">
+    <% if current_user.guest? %>
+      <div class="alert bg-danger text-light fs-4 text-center my-5 p-2" role="alert">
+        <i class="fas fa-exclamation-triangle"></i>
+        ゲストユーザーのためプロフィール編集はできません
+      </div>
+    <% end %>
     <h2 class="form-title">プロフィール編集</h2>
 
     <%= form_with model: @user, url: user_registration_path, method: :patch, local: true do |f| %>
@@ -7,27 +13,27 @@
         <div class="label-container">
           <%= f.label :name, "ユーザー名", class: "form-label" %>
         </div>
-        <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "form-control" %>
+        <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "form-control", disabled: current_user.guest? %>
       </div>
 
       <div class="field mb-5">
         <div class="label-container">
           <%= f.label :avatar, "プロフィール画像", class: "form-label" %>
         </div>
-        <%= f.file_field :avatar, accept: 'image/jpeg, image/jpg, image/png, image/bmp', class: "form-control" %>
+        <%= f.file_field :avatar, accept: 'image/jpeg, image/jpg, image/png, image/bmp', class: "form-control", disabled: current_user.guest? %>
       </div>
 
       <div class="field mb-5">
         <div class="label-container">
           <%= f.label :introduction, "自己紹介", class: "form-label" %>
         </div>
-        <%= f.text_area :introduction, autocomplete: "introduction", class: "form-control", rows: 5 %>
+        <%= f.text_area :introduction, autocomplete: "introduction", class: "form-control", rows: 5, disabled: current_user.guest? %>
       </div>
 
       <%= hidden_field_tag :form_type, 'profile_edit' %>
 
       <div class="actions mb-3 pt-4 d-grid mx-auto">
-        <%= f.submit "更新", class: "btn" %>
+        <%= f.submit "更新", class: "btn", disabled: current_user.guest? %>
       </div>
     <% end %>
   </div>

--- a/app/views/users/show_favorites.html.erb
+++ b/app/views/users/show_favorites.html.erb
@@ -3,7 +3,7 @@
     <div class="user-info-and-link-profile">
       <div class="icon-image-lg">
         <%= user_avatar_image_tag(@user) %>
-        <p><%= @user.name %>さん</p>
+        <p><%= @user.name %></p>
       </div>
       <% if @user == current_user %>
         <div class="edit-profile-btn-container">

--- a/app/views/users/show_mygadgets.html.erb
+++ b/app/views/users/show_mygadgets.html.erb
@@ -3,7 +3,7 @@
     <div class="user-info-and-link-profile">
       <div class="icon-image-lg">
         <%= user_avatar_image_tag(@user) %>
-        <p><%= @user.name %>さん</p>
+        <p><%= @user.name %></p>
       </div>
       <% if @user == current_user %>
         <div class="edit-profile-btn-container">


### PR DESCRIPTION
#147 
【実装機能概要】

- ゲストユーザーがプロフィール編集できないようにする
- ゲストユーザーがアカウント情報編集できないようにする
- 【誤植訂正】新規登録ページのユーザー名の最大文字数の表記を”以上”から”以下”へ
- トップページの「一覧はこちら」ボタンのトップにmarginを設定
- マイページのユーザー名の”さん”を削除