### PR TITLE
バリデーションメッセージの設定 #102

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -11,6 +11,7 @@ class CommentsController < ApplicationController
       redirect_to gadget_path(@gadget)
     else
       flash[:alert] = "コメントの投稿に失敗しました。"
+      @gadget.comments.delete(@comment)
       render 'gadgets/show'
     end
   end

--- a/app/controllers/gadgets_controller.rb
+++ b/app/controllers/gadgets_controller.rb
@@ -14,6 +14,7 @@ class GadgetsController < ApplicationController
 
   def show
     @gadget = Gadget.find(params[:id])
+    @comment = Comment.new
     @comments = @gadget.comments.order('created_at ASC').limit(5)
   end
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -21,17 +21,73 @@ ActiveStorage.start()
 // コメント一覧ページにてガジェット詳細を開く・閉じる
 document.addEventListener('DOMContentLoaded', () => {
   const collapseButton = document.querySelector('[data-bs-toggle="collapse"]');
-  const collapseText = collapseButton.querySelector('.collapse-text');
 
-  collapseButton.addEventListener('click', () => {
-    if (collapseButton.getAttribute('aria-expanded') === 'true') {
-      console.log('開く');
-      collapseText.textContent = '▼ ガジェット詳細を閉じる';
-    } else {
-      console.log('閉じる');
-      collapseText.textContent = '▲ ガジェット詳細を見る';
-    }
-  });
+  if (collapseButton) {
+    const collapseText = collapseButton.querySelector('.collapse-text');
+
+    collapseButton.addEventListener('click', () => {
+      if (collapseButton.getAttribute('aria-expanded') === 'true') {
+        console.log('開く');
+        collapseText.textContent = '▼ ガジェット詳細を閉じる';
+      } else {
+        console.log('閉じる');
+        collapseText.textContent = '▲ ガジェット詳細を見る';
+      }
+    });
+  }
 });
 
+// コメント入力欄が未入力の場合送信ボタンを無効化
+// document.addEventListener('DOMContentLoaded', () => {
+//   const commentInput = document.getElementById('comment-input');
+//   const submitButton = document.getElementById('submit-button');
+
+//   // コメント入力欄の内容が変更されたときに呼び出される関数
+//   function onCommentInputChange() {
+//     if (commentInput.value.trim() === '') {
+//       submitButton.disabled = true;
+//     } else {
+//       submitButton.disabled = false;
+//     }
+//   }
+
+//   // コメント入力欄の初期状態に基づいて、送信ボタンの無効化/有効化を設定
+//   onCommentInputChange();
+
+//   // コメント入力欄の内容が変更されたときに、送信ボタンの無効化/有効化を更新
+//   commentInput.addEventListener('input', onCommentInputChange);
+
+//   console.log("Hello")
+// });
+
+
+// コメント入力欄が未入力の場合送信ボタンを無効化
+function onCommentInputChange() {
+  const commentInput = document.getElementById('comment-input');
+  const submitButton = document.getElementById('submit-button');
+
+  if (!commentInput || !submitButton) {
+    return;
+  }
+
+  if (commentInput.value.trim() === '') {
+    submitButton.disabled = true;
+  } else {
+    submitButton.disabled = false;
+  }
+}
+
+function initializeCommentFormValidation() {
+  const commentInput = document.getElementById('comment-input');
+
+  if (!commentInput) {
+    return;
+  }
+
+  onCommentInputChange();
+  commentInput.addEventListener('input', onCommentInputChange);
+}
+
+document.addEventListener('DOMContentLoaded', initializeCommentFormValidation);
+document.addEventListener('turbolinks:load', initializeCommentFormValidation);
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -5,5 +5,4 @@ class Comment < ApplicationRecord
   validates :content, presence: true, length: { minimum: 1, maximum: 400 }
   validates :user_id, presence: true
   validates :gadget_id, presence: true
-
 end

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -87,13 +87,13 @@
         <% end %>
       </div>
       <% if user_signed_in? %>
-        <%= form_with(model: [ @gadget, @gadget.comments.build ], local: true) do |form| %>
+        <%= form_with(model: [ @gadget, @comment ], local: true) do |form| %>
           <div class="row mt-5">
             <div class="col-10 col-md-11">
-              <%= form.text_area :content, rows: 1, class: "form-control h-100" %>
+              <%= form.text_area :content, rows: 1, class: "form-control h-100", id: "comment-input" %>
             </div>
             <div class="col-2 col-md-1 d-flex align-items-center">
-              <%= form.submit "送信", class: "btn btn-secondary text-light fw-bold fs-5 h-100" %>
+              <%= form.submit "送信", class: "btn btn-secondary text-light fw-bold fs-5 h-100", id: "submit-button" %>
             </div>
           </div>
         <% end %>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,12 +1,12 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation">
-    <h2>
+  <div id="error_explanation" class="my-5 text-dan  ger">
+    <h4>
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,
                  resource: resource.class.model_name.human.downcase)
        %>
-    </h2>
-    <ul>
+    </h4>
+    <ul class="list-unstyled fs-4 text-danger">
       <% resource.errors.full_messages.each do |message| %>
         <li><%= message %></li>
       <% end %>

--- a/app/views/gadgets/show.html.erb
+++ b/app/views/gadgets/show.html.erb
@@ -57,7 +57,7 @@
       </div>
     </div>
 
-    <% if @gadget.user_id == current_user.id %>
+    <% if current_user && @gadget.user_id == current_user.id %>
       <div class="edit-btn-container">
         <%= link_to '編集する', edit_gadget_path(@gadget), class: "btn edit-btn" %>
       </div>
@@ -98,14 +98,15 @@
           </div>
         <% end %>
       </div>
+
       <% if user_signed_in? %>
-        <%= form_with(model: [ @gadget, @gadget.comments.build ], local: true) do |form| %>
+        <%= form_with(model: [ @gadget, @comment ], local: true) do |form| %>
           <div class="row mt-5">
             <div class="col-10 col-md-11">
-              <%= form.text_area :content, rows: 1, class: "form-control h-100" %>
+              <%= form.text_area :content, rows: 1, class: "form-control h-100", id: "comment-input" %>
             </div>
             <div class="col-2 col-md-1 d-flex align-items-center">
-              <%= form.submit "送信", class: "btn btn-secondary text-light fw-bold fs-5 h-100" %>
+              <%= form.submit "送信", class: "btn btn-secondary text-light fw-bold fs-5 h-100", id: "submit-button" %>
             </div>
           </div>
         <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,10 +20,10 @@
     <% end %>
 
     <% if flash[:notice] %>
-      <p class="notice"><%= notice %></p>
+      <p class="notice text-center bg-secondary text-light fs-3"><%= notice %></p>
     <% end %>
     <% if flash[:alert] %>
-      <p class="alert"><%= alert %></p>
+      <p class="alert text-center bg-danger text-light fs-3"><%= alert %></p>
     <% end %>
     <%= yield %>
     <%= render 'shared/footer' %>

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,143 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザー
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントはロックされています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: ログインもしくはアカウント登録してください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: メールアドレスの（%{email}）変更が完了したため、メールを送信しています。
+        message_unconfirmed: メールアドレスが（%{email}）変更されたため、メールを送信しています。
+        subject: メール変更完了
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されました。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントのロック解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか？
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか？
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードを忘れましたか？
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: はロックされていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -37,7 +37,7 @@ ja:
     failure:
       already_authenticated: すでにログインしています。
       inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
-      invalid: "%{authentication_keys}またはパスワードが違います。"
+      invalid: "%{authentication_keys}またはパスワードが違います"
       last_attempt: もう一回誤るとアカウントがロックされます。
       locked: アカウントはロックされています。
       not_found_in_database: "%{authentication_keys}またはパスワードが違います。"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   devise_for :users,
     controllers: {
       registrations: 'users/registrations',
-      passwords: 'users/passwords', 
+      passwords: 'users/passwords',
       sessions: 'users/sessions'
     }
 


### PR DESCRIPTION
#102 
【実装機能概要】
- deviseのエラーメッセージを日本語化
- バリデーションメッセージが必要なページの洗い出し
  - 新規登録ページ
  - パスワード再設定ページ
  - ガジェット編集ページ
  - ガジェット登録ページ
  - プロフィール編集ページ
  - アカウント情報編集ページ
- 各ページのバリデーションメッセージ内容の修正
- バリデーションメッセージのレイアウト修正
- 【エラー解消】空白でコメントを送信した場合のエラー：「ArgumentError in Comments#create」の解消
- コメント欄が未入力の場合、送信ボタンを押せないように設定
- ガジェット編集ページに「キャンセル」ボタンを追加
- アカウントを削除／ガジェットを削除のリンクをホバー時に色が薄くなるようにcssを設定
- プロフィール編集ページにてバリデーションエラーになった際にアカウント情報編集ページへ遷移してしまう問題を解消