### PR TITLE
バリデーションメッセージの設定 #102

### DIFF
--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -40,6 +40,10 @@
     font-size: 2rem;
     font-weight: 550;
   }
+
+  .btn:hover {
+    opacity: 0.8;
+  }
 }
 
 // ガジェット詳細画面の編集ボタン
@@ -87,4 +91,9 @@
     right: 20px;
     z-index: 990;
   }
+}
+
+// ガジェット削除／アカウント削除のリンク（ボタン）
+.delete-button:hover {
+  opacity: 0.7;
 }

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -8,6 +8,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
         when 'profile_edit' then redirect_to mygadgets_user_path(current_user.id) and return
         when 'account_edit' then redirect_to account_user_path(current_user.id) and return
         end
+      else
+        case params[:form_type]
+        when 'profile_edit' then render 'users/edit_profile' and return
+        when 'account_edit' then render :edit and return
+        end
       end
     end
   end

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,14 +1,8 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation" class="my-5 text-dan  ger">
-    <h4>
-      <%= I18n.t("errors.messages.not_saved",
-                 count: resource.errors.count,
-                 resource: resource.class.model_name.human.downcase)
-       %>
-    </h4>
-    <ul class="list-unstyled fs-4 text-danger">
+  <div id="error_explanation" class="my-5 text-danger  text-center">
+    <ul class="list-unstyled fs-4">
       <% resource.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
+        <li class="mt-2"><%= message %></li>
       <% end %>
     </ul>
   </div>

--- a/app/views/gadgets/edit.html.erb
+++ b/app/views/gadgets/edit.html.erb
@@ -3,15 +3,18 @@
     <h2 class="form-title">ガジェットを編集</h2>
 
     <%= form_with model: @gadget, url: gadget_path, local: true do |f| %>
+      <%= render "devise/shared/error_messages", resource: @gadget %>
       <div class="field mb-5">
         <div class="label-container">
           <%= f.label :name, "ガジェット名", class: "form-label" %>
+          <span class="required-mark">必須</span>
         </div>
         <%= f.text_field :name, autofocus: true, class: "form-control" %>
       </div>
       <div class="field mb-5">
         <div class="label-container">
           <%= f.label :category, class: "form-label" %>
+          <span class="required-mark">必須</span>
         </div>
         <%= f.text_field :category, class: "form-control" %>
       </div>
@@ -30,6 +33,7 @@
       <div class="field mb-5">
         <div class="label-container">
           <%= f.label :point, class: "form-label" %>
+          <span class="required-mark">必須</span>
         </div>
         <%= f.text_area :point, class: "form-control", rows: 8 %>
       </div>
@@ -49,9 +53,12 @@
         <%= f.submit "更新", class: "btn" %>
       </div>
     <% end %>
+    <div class="d-grid">
+      <%= link_to "キャンセル", :back, class: "btn btn-outline-dark mt-5 fs-3 py-2" %>
+    </div>
 
     <div class="text-center mt-56">
-      <button type="button" class="text-info border-0 bg-light fs-4" data-bs-toggle="modal" data-bs-target="#deleteGadgetModal">
+      <button type="button" class="delete-button text-info border-0 bg-light fs-4" data-bs-toggle="modal" data-bs-target="#deleteGadgetModal">
         ガジェットを削除する
       </button>
     </div>

--- a/app/views/gadgets/new.html.erb
+++ b/app/views/gadgets/new.html.erb
@@ -3,6 +3,7 @@
     <h2 class="form-title">ガジェットを登録</h2>
 
     <%= form_with model: @gadget, url: gadgets_path, local: true do |f| %>
+      <%= render "devise/shared/error_messages", resource: @gadget %>
       <div class="field mb-5">
         <div class="label-container">
           <%= f.label :name, "ガジェット名", class: "form-label" %>

--- a/app/views/users/account.html.erb
+++ b/app/views/users/account.html.erb
@@ -14,7 +14,7 @@
     </div>
 
     <div class="text-center mt-64">
-      <button type="button" class="text-info border-0 bg-light fs-2 fw-bold" data-bs-toggle="modal" data-bs-target="#deleteAccountModal">
+      <button type="button" class="delete-button text-info border-0 bg-light fs-2 fw-bold" data-bs-toggle="modal" data-bs-target="#deleteAccountModal">
         アカウントを削除する
       </button>
     </div>

--- a/app/views/users/edit_profile.html.erb
+++ b/app/views/users/edit_profile.html.erb
@@ -9,9 +9,11 @@
     <h2 class="form-title">プロフィール編集</h2>
 
     <%= form_with model: @user, url: user_registration_path, method: :patch, local: true do |f| %>
+      <%= render "devise/shared/error_messages", resource: @user %>
       <div class="field mb-5">
         <div class="label-container">
           <%= f.label :name, "ユーザー名", class: "form-label" %>
+          <span class="required-mark">必須</span>
         </div>
         <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "form-control", disabled: current_user.guest? %>
       </div>

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -140,4 +140,4 @@ ja:
       not_locked: はロックされていません。
       not_saved:
         one: エラーが発生したため %{resource} は保存されませんでした。
-        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"
+        other: ""

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -20,6 +20,7 @@ ja:
         point: '推しポイント'
         reason: '選んだ理由'
         usage: '使用用途'
+        name: 'ガジェット名'
   views:
     pagination:
       first: <i class="fas fa-angle-double-left"></i>


### PR DESCRIPTION
#102
【実装機能概要】 
- deviseのエラーメッセージを日本語化
- バリデーションメッセージが必要なページの洗い出し
  - 新規登録ページ
  - パスワード再設定ページ
  - ガジェット編集ページ
  - ガジェット登録ページ
  - プロフィール編集ページ
  - アカウント情報編集ページ
- 各ページのバリデーションメッセージ内容の修正
- バリデーションメッセージのレイアウト修正
- 【エラー解消】空白でコメントを送信した場合のエラー：「ArgumentError in Comments#create」の解消
- コメント欄が未入力の場合、送信ボタンを押せないように設定
- ガジェット編集ページに「キャンセル」ボタンを追加
- アカウントを削除／ガジェットを削除のリンクをホバー時に色が薄くなるようにcssを設定
- プロフィール編集ページにてバリデーションエラーになった際にアカウント情報編集ページへ遷移してしまう問題を解消