### PR TITLE
Multiple minor corrections #162

### DIFF
--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -97,3 +97,10 @@
 .delete-button:hover {
   opacity: 0.7;
 }
+
+// フォローボタン
+.follow-btn:hover {
+  background-color: $color-first;
+  color: $color-fourth;
+  opacity: 0.7;
+}

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -8,11 +8,19 @@ class CommentsController < ApplicationController
     @comment.user = current_user
 
     if @comment.save
-      redirect_to gadget_path(@gadget)
+      if request.referer.include?("comments")
+        redirect_to gadget_comments_path(@gadget)
+      else
+        redirect_to gadget_path(@gadget)
+      end
     else
       flash[:alert] = "コメントの投稿に失敗しました。"
       @gadget.comments.delete(@comment)
-      render 'gadgets/show'
+      if request.referer.include?("comments")
+        render 'comments/index'
+      else
+        render 'gadgets/show'
+      end
     end
   end
 
@@ -22,11 +30,17 @@ class CommentsController < ApplicationController
 
     if @comment.user == current_user
       @comment.destroy
+      if request.referer.include?("comments")
+        redirect_to gadget_comments_path(@gadget)
+      else
+        redirect_to gadget_path(@gadget)
+      end
     end
   end
 
   def index
     @gadget = Gadget.find(params[:gadget_id])
+    @comment = Comment.new
   end
 
   private

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -14,7 +14,7 @@ class CommentsController < ApplicationController
         redirect_to gadget_path(@gadget)
       end
     else
-      flash[:alert] = "コメントの投稿に失敗しました。"
+      flash[:alert] = "コメントの投稿に失敗しました"
       @gadget.comments.delete(@comment)
       if request.referer.include?("comments")
         render 'comments/index'
@@ -29,6 +29,7 @@ class CommentsController < ApplicationController
     @comment = @gadget.comments.find(params[:id])
 
     if @comment.user == current_user
+      flash[:notice] = "コメントを削除しました"
       @comment.destroy
       if request.referer.include?("comments")
         redirect_to gadget_comments_path(@gadget)
@@ -52,7 +53,7 @@ class CommentsController < ApplicationController
   def ensure_correct_user
     comment = Comment.find(params[:id])
     unless comment.user_id == current_user.id
-      flash[:alert] = "権限がありません。"
+      flash[:alert] = "権限がありません"
       redirect_to(root_path)
     end
   end

--- a/app/controllers/gadgets_controller.rb
+++ b/app/controllers/gadgets_controller.rb
@@ -45,8 +45,8 @@ class GadgetsController < ApplicationController
 
   # DELETE /gadgets/1 or /gadgets/1.json
   def destroy
+    flash[:notice] = "ガジェットを削除しました"
     @gadget.destroy
-
     respond_to do |format|
       format.html { redirect_to gadgets_url, notice: "Gadget was successfully destroyed." }
       format.json { head :no_content }
@@ -71,7 +71,7 @@ class GadgetsController < ApplicationController
 
     def ensure_correct_user
       if @gadget.user_id != current_user.id
-        flash[:alert] = "権限がありません。"
+        flash[:alert] = "権限がありません"
         redirect_to gadget_path
       end
     end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -3,7 +3,7 @@ class Users::PasswordsController < Devise::PasswordsController
 
   def ensure_normal_user
     if params[:user][:email].downcase == 'guest@example.com'
-      redirect_to new_user_session_path, alert: 'ゲストユーザーのパスワード再設定はできません。'
+      redirect_to new_user_session_path, alert: 'ゲストユーザーのパスワード再設定はできません'
     end
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -2,17 +2,22 @@ class Users::RegistrationsController < Devise::RegistrationsController
   before_action :ensure_normal_user, only: %i[update destroy]
 
   def update
-    super do |resource|
-      if resource.errors.empty?
-        case params[:form_type]
-        when 'profile_edit' then redirect_to mygadgets_user_path(current_user.id) and return
-        when 'account_edit' then redirect_to account_user_path(current_user.id) and return
-        end
-      else
-        case params[:form_type]
-        when 'profile_edit' then render 'users/edit_profile' and return
-        when 'account_edit' then render :edit and return
-        end
+    success = update_resource_without_redirect
+
+    if success
+      case params[:form_type]
+      when 'profile_edit'
+        redirect_to mygadgets_user_path(current_user.id) and return
+      when 'account_edit'
+        bypass_sign_in(resource) if sign_in_after_change_password?
+        redirect_to account_user_path(current_user.id) and return
+      end
+    else
+      case params[:form_type]
+      when 'profile_edit'
+        render 'users/edit_profile' and return
+      when 'account_edit'
+        render :edit and return
       end
     end
   end
@@ -30,12 +35,14 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   private
 
+  # ゲストユーザーの場合は編集・削除できないようにする
   def ensure_normal_user
     if resource.email == 'guest@example.com'
       redirect_to root_path, alert: 'ゲストユーザーの更新・削除はできません。'
     end
   end
 
+  # ユーザー情報の項目により変更時のパスワードの有無を判断する
   def update_resource(resource, params)
     if params[:email].present? || params[:password].present?
       # メールアドレス/パスワードの更新の場合には現在のパスワードが必要
@@ -44,5 +51,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
       # ユーザー名/自己紹介/アバター画像の更新の場合には現在のパスワードは不要
       resource.update_without_current_password(params)
     end
+  end
+
+  # 更新を試みて成功・失敗をブール値で返す（リダイレクトなし）
+  def update_resource_without_redirect
+    update_resource(resource, account_update_params)
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -7,9 +7,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
     if success
       case params[:form_type]
       when 'profile_edit'
+        flash[:notice] = "プロフィール情報を更新しました"
         redirect_to mygadgets_user_path(current_user.id) and return
       when 'account_edit'
         bypass_sign_in(resource) if sign_in_after_change_password?
+        flash[:notice] = "アカウント情報を更新しました"
         redirect_to account_user_path(current_user.id) and return
       end
     else
@@ -25,10 +27,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def destroy
     resource.destroy
     if resource.destroyed?
-      flash[:notice] = "お客様のアカウントは正常に削除されました。"
+      flash[:notice] = "お客様のアカウントは正常に削除されました"
       redirect_to root_path
     else
-      flash[:alert] = "アカウントの削除にエラーが発生しました。"
+      flash[:alert] = "アカウントの削除にエラーが発生しました"
       redirect_back(fallback_location: root_path)
     end
   end
@@ -38,7 +40,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # ゲストユーザーの場合は編集・削除できないようにする
   def ensure_normal_user
     if resource.email == 'guest@example.com'
-      redirect_to root_path, alert: 'ゲストユーザーの更新・削除はできません。'
+      redirect_to root_path, alert: 'ゲストユーザーの更新・削除はできません'
     end
   end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -2,6 +2,6 @@ class Users::SessionsController < Devise::SessionsController
   def guest_sign_in
     user = User.guest
     sign_in user
-    redirect_to root_path, notice: 'ゲストユーザーとしてログインしました。'
+    redirect_to root_path, notice: 'ゲストユーザーとしてログインしました'
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,7 +29,7 @@ class UsersController < ApplicationController
 
   def ensure_correct_user
     if current_user.id != params[:id].to_i
-      flash[:alert] = "権限がありません。"
+      flash[:alert] = "権限がありません"
       redirect_to root_path
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,6 +48,7 @@ class User < ApplicationRecord
 
   # 他のユーザーをフォローするメソッド
   def follow(other_user)
+    return if self == other_user  # 自分自身をフォローしようとした場合、処理をスキップする
     active_relationships.create(followed_id: other_user.id)
   end
 

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -82,7 +82,7 @@
                 <% end %>
               </div>
             </div>
-            <P class="ps-2 fs-5"><%= comment.content %></P>
+            <P class="ps-2 fs-5"><%= safe_join(comment.content.split("\n"),tag(:br)) %></P>
           </div>
         <% end %>
       </div>

--- a/app/views/gadgets/liked_users.html.erb
+++ b/app/views/gadgets/liked_users.html.erb
@@ -33,7 +33,7 @@
             <% end %>
           </div>
           <div class="detail-link-container mt-4">
-            <P><%= link_to "＞ ユーザー詳細へ", users_path(user.id), class: "btn detail-link" %></P>
+            <P><%= link_to "＞ ユーザー詳細へ", mygadgets_user_path(user.id), class: "btn detail-link" %></P>
           </div>
         </div>
       <% end %>

--- a/app/views/gadgets/show.html.erb
+++ b/app/views/gadgets/show.html.erb
@@ -92,14 +92,14 @@
                 <% end %>
               </div>
             </div>
-            <P class="ps-2 fs-5"><%= comment.content %></P>
+            <P class="ps-2 fs-5"><%= safe_join(comment.content.split("\n"),tag(:br)) %></P>
           </div>
         <% end %>
       </div>
 
       <% if user_signed_in? %>
         <%= form_with(model: [ @gadget, @comment ], local: true) do |form| %>
-          <%= render "devise/shared/error_messages", resource: resource %>
+          <%= render "devise/shared/error_messages", resource: @comment %>
           <div class="row mt-5">
             <div class="col-10 col-md-11">
               <%= form.text_area :content, rows: 1, class: "form-control h-100", id: "comment-input" %>

--- a/app/views/gadgets/show.html.erb
+++ b/app/views/gadgets/show.html.erb
@@ -88,7 +88,7 @@
               </div>
               <div class="d-flex align-items-end">
                 <% if comment.user == current_user %>
-                  <%= link_to "削除", [comment.gadget, comment], method: :delete, data: { confirm: "本当に削除しますか？" } %>
+                  <%= link_to "削除", gadget_comment_path(comment.gadget, comment), method: :delete, data: { confirm: "本当に削除しますか？" } %>
                 <% end %>
               </div>
             </div>

--- a/app/views/gadgets/top.html.erb
+++ b/app/views/gadgets/top.html.erb
@@ -131,7 +131,7 @@
               <% end %>
             </div>
             <div class="detail-link-container">
-              <P><%= link_to "＞ ユーザー詳細へ", users_path(user.id), class: "btn detail-link" %></P>
+              <P><%= link_to "＞ ユーザー詳細へ", mygadgets_user_path(user.id), class: "btn detail-link" %></P>
             </div>
           </div>
         </div>

--- a/app/views/relationships/followers.html.erb
+++ b/app/views/relationships/followers.html.erb
@@ -47,7 +47,7 @@
             <% end %>
           </div>
           <div class="detail-link-container mt-4">
-            <P><%= link_to "＞ ユーザー詳細へ", users_path(user.id), class: "btn detail-link" %></P>
+            <P><%= link_to "＞ ユーザー詳細へ", mygadgets_user_path(user.id), class: "btn detail-link" %></P>
           </div>
         </div>
       <% end %>

--- a/app/views/relationships/followings.html.erb
+++ b/app/views/relationships/followings.html.erb
@@ -47,7 +47,7 @@
             <% end %>
           </div>
           <div class="detail-link-container mt-4">
-            <P><%= link_to "＞ ユーザー詳細へ", users_path(user.id), class: "btn detail-link" %></P>
+            <P><%= link_to "＞ ユーザー詳細へ", mygadgets_user_path(user.id), class: "btn detail-link" %></P>
           </div>
         </div>
       <% end %>

--- a/app/views/shared/_follow-and-unfollow.html.erb
+++ b/app/views/shared/_follow-and-unfollow.html.erb
@@ -1,9 +1,11 @@
-<% if current_user && current_user.following?(user) %>
-  <%= form_with url: user_relationships_path(user_id: user), method: :delete, local: false do |f| %>
-    <%= f.submit "フォロー中", class: "follow-btn btn btn-secondary rounded-pill btn-sm text-light" %>
-  <% end %>
-<% else %>
-  <%= form_with url: user_relationships_path(user_id: user), method: :post, local: false do |f| %>
-    <%= f.submit "フォロー", class: "follow-btn btn btn-light btn-outline-dark rounded-pill btn-sm" %>
+<% unless current_user == user %>
+  <% if current_user && current_user.following?(user) %>
+    <%= form_with url: user_relationships_path(user_id: user), method: :delete, local: false do |f| %>
+      <%= f.submit "フォロー中", class: "follow-btn btn btn-secondary rounded-pill btn-sm text-light" %>
+    <% end %>
+  <% else %>
+    <%= form_with url: user_relationships_path(user_id: user), method: :post, local: false do |f| %>
+      <%= f.submit "フォロー", class: "follow-btn btn btn-light btn-outline-dark rounded-pill btn-sm" %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/shared/_follow-and-unfollow.html.erb
+++ b/app/views/shared/_follow-and-unfollow.html.erb
@@ -1,7 +1,7 @@
 <% unless current_user == user %>
   <% if current_user && current_user.following?(user) %>
     <%= form_with url: user_relationships_path(user_id: user), method: :delete, local: false do |f| %>
-      <%= f.submit "フォロー中", class: "follow-btn btn btn-secondary rounded-pill btn-sm text-light" %>
+      <%= f.submit "フォロー中", class: "following-btn btn btn-secondary rounded-pill btn-sm text-light" %>
     <% end %>
   <% else %>
     <%= form_with url: user_relationships_path(user_id: user), method: :post, local: false do |f| %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -45,7 +45,7 @@
               <% end %>
             </div>
             <div class="detail-link-container">
-              <P><%= link_to "＞ ユーザー詳細へ", users_path(user.id), class: "btn detail-link" %></P>
+              <P><%= link_to "＞ ユーザー詳細へ", mygadgets_user_path(user.id), class: "btn detail-link" %></P>
             </div>
           </div>
         </div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -307,5 +307,5 @@ Devise.setup do |config|
 
   # When set to false, does not sign a user in automatically after their password is
   # changed. Defaults to true, so a user is signed in automatically after changing a password.
-  # config.sign_in_after_change_password = true
+  config.sign_in_after_change_password = true
 end


### PR DESCRIPTION
#162 
【実装機能概要】

- 「＞ユーザー詳細へ」ボタンのリンク先の修正
- ユーザー一覧に出てきたユーザーが自分自身の場合にはフォローボタンを非表示にする
- 自分をフォローできないようにする
- フォローボタンをhover時の色をかえる（フォロー中の背景色と被るため、黒→白色へ）
- コメント入力欄で改行した場合、送信後のコメント表示でも改行された状態で表示されるようにする
- コメントの削除を押下しても削除されないという不具合の修正
- コメント作成・削除した際にガジェット詳細ページ、コメント一覧ページのうち作業を行った方のページに遷移するように場合分けを行う
- パスワードを変更した際、ログアウトしないように設定変更
- フラッシュメッセージの修正