### PR TITLE
タグ付け機能の追加 #193

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,6 @@ group :development, :test do
   gem 'faker'
   gem 'rspec-rails'
   gem 'factory_bot_rails'
-  gem 'rails-erd'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,8 @@ gem 'kaminari'
 gem 'meta-tags'
 # 検索機能
 gem 'ransack'
+# タグ付け機能
+gem 'acts-as-taggable-on'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,8 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    acts-as-taggable-on (9.0.1)
+      activerecord (>= 6.0, < 7.1)
     addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
     aws-eventstream (1.2.0)
@@ -322,6 +324,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  acts-as-taggable-on
   aws-sdk-s3
   bootsnap (>= 1.4.4)
   byebug

--- a/app/assets/stylesheets/components/_parts.scss
+++ b/app/assets/stylesheets/components/_parts.scss
@@ -25,10 +25,13 @@
     border-radius: 20px;
     display: inline-block;
     background-color: $color-third;
-    color: $color-first;
     padding: 2px 10px;
     font-size: 1.2rem;
     margin-left: 5px;
+
+    a {
+      color: $color-first;
+    }
   }
 
   .likes-and-comments-container {

--- a/app/assets/stylesheets/gadgets/_show.scss
+++ b/app/assets/stylesheets/gadgets/_show.scss
@@ -12,5 +12,3 @@
 .comments-container {
   margin-top: 80px;
 }
-
-

--- a/app/controllers/gadgets_controller.rb
+++ b/app/controllers/gadgets_controller.rb
@@ -66,7 +66,7 @@ class GadgetsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def gadget_params
-      params.require(:gadget).permit(:user_id, :name, :start_date, :category, :reason, :point, :usage, :image).merge(user_id:current_user.id)
+      params.require(:gadget).permit(:user_id, :name, :start_date, :category_list, :reason, :point, :usage, :image).merge(user_id:current_user.id)
     end
 
     def ensure_correct_user

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -3,18 +3,18 @@ class SearchesController < ApplicationController
     @q = params[:q]
     @model = params[:model].presence || 'gadgets'
     if @q.present?
-      if @model == 'users'
-        @users = User.ransack(name_or_introduction_cont: @q).result(distinct: true)
-      else
-        @gadgets = Gadget.ransack(name_or_reason_or_usage_or_point_cont: @q).result(distinct: true)
-      end
+        case @model
+        when 'users'
+            @users = User.ransack(name_or_introduction_cont: @q).result(distinct: true)
+        when 'gadgets'
+            @gadgets = Gadget.ransack(name_or_reason_or_usage_or_point_cont: @q).result(distinct: true)
+        when 'categories'
+            @gadgets = Gadget.tagged_with(@q)
+        end
     end
-
-    # binding.pry
-
     respond_to do |format|
-      format.html
-      format.js
+        format.html
+        format.js
     end
-  end
+end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -75,8 +75,20 @@ document.addEventListener('turbolinks:load', initializeCommentFormValidation);
 
 // 検索結果ページにて検索対象タブ（投稿orユーザー）を保存しておくために、検索モデルをhidden_fieldにセット
 $(document).on('turbolinks:load', function() {
-  $('#gadget-link, #user-link').on('click', function(e) {
-    var model = $(this).attr('id') === 'gadget-link' ? 'gadgets' : 'users';
+  $('#gadget-link, #user-link, #category-link').on('click', function(e) {
+    var model;
+    switch ($(this).attr('id')) {
+      case 'gadget-link':
+        model = 'gadgets';
+        break;
+      case 'user-link':
+        model = 'users';
+        break;
+      case 'category-link':
+        model = 'categories';
+        break;
+    }
     $('#hidden-model').val(model);
   });
 });
+

--- a/app/models/gadget.rb
+++ b/app/models/gadget.rb
@@ -6,7 +6,6 @@ class Gadget < ApplicationRecord
   acts_as_taggable_on :categories
 
   validates :name, presence: true
-  validates :category, presence: true
   validates :point, presence: true
 
   # いいね済かどうかの判定

--- a/app/models/gadget.rb
+++ b/app/models/gadget.rb
@@ -3,6 +3,7 @@ class Gadget < ApplicationRecord
   has_one_attached :image
   has_many :likes, dependent: :destroy
   has_many :comments, dependent: :destroy
+  acts_as_taggable_on :categories
 
   validates :name, presence: true
   validates :category, presence: true

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -31,7 +31,11 @@
       </div>
       <div class="gadget-detail">
         <p class="category">カテゴリー</p>
-        <P class="content"><%= @gadget.category %></P>
+        <p class="content">
+          <% @gadget.category_list.each do |category| %>
+            <i class="fa-solid fa-tag" style="color: #393e46;"></i><%= link_to category, searches_path(q: category, model: 'categories'), class: "me-3" %>
+          <% end %>
+        </p>
       </div>
       <div class="gadget-detail">
         <p class="category">使用開始日</p>

--- a/app/views/gadgets/edit.html.erb
+++ b/app/views/gadgets/edit.html.erb
@@ -14,10 +14,10 @@
       </div>
       <div class="field mb-5">
         <div class="label-container">
-          <%= f.label :category, class: "form-label" %>
+          <%= f.label :category_list, class: "form-label" %>
           <span class="required-mark">必須</span>
         </div>
-        <%= f.text_field :category, class: "form-control", required: true %>
+        <%= f.text_field :category_list, value: @gadget.category_list.join(','), class: "form-control", required: true %>
       </div>
       <div class="field mb-5">
         <div class="label-container">

--- a/app/views/gadgets/index.html.erb
+++ b/app/views/gadgets/index.html.erb
@@ -23,7 +23,11 @@
                   </div>
                 <% end %>
                 <p class="gadget-name"><%= gadget.name %></p>
-                <p class="gadget-category"><%= gadget.category %></p>
+                <p class="gadget-category">
+                  <% gadget.category_list.each do |category| %>
+                    <%= link_to category, searches_path(q: category, model: 'categories') %>
+                  <% end %>
+                </p>
                 <%# いいねとコメント %>
                 <div class="likes-and-comments-container d-flex fs-4">
                   <div class="likes" id="likes-<%= gadget.id %>">
@@ -36,9 +40,11 @@
                   </div>
                 </div>
               </div>
-              <div class="gadget-image-md">
-                <%= image_tag gadget.image %>
-              </div>
+              <% if gadget.image.present? %>
+                <div class="gadget-image-md">
+                  <%= image_tag gadget.image %>
+                </div>
+              <% end %>
             </div>
             <div class="detail-link-container">
               <%= link_to "＞ 投稿詳細へ", gadget_path(gadget), class: "btn detail-link" %>

--- a/app/views/gadgets/new.html.erb
+++ b/app/views/gadgets/new.html.erb
@@ -14,10 +14,10 @@
       </div>
       <div class="field mb-5">
         <div class="label-container">
-          <%= f.label :category, class: "form-label" %>
+          <%= f.label :category_list, class: "form-label" %>
           <span class="required-mark">必須</span>
         </div>
-        <%= f.text_field :category, class: "form-control", required: true %>
+        <%= f.text_field :category_list, value: @gadget.category_list.join(','), class: "form-control", required: true %>
       </div>
       <div class="field mb-5">
         <div class="label-container">

--- a/app/views/gadgets/show.html.erb
+++ b/app/views/gadgets/show.html.erb
@@ -36,7 +36,11 @@
       </div>
       <div class="gadget-detail">
         <p class="category">カテゴリー</p>
-        <P class="content"><%= @gadget.category %></P>
+        <p class="content">
+          <% @gadget.category_list.each do |category| %>
+            <i class="fa-solid fa-tag" style="color: #393e46;"></i><%= link_to category, searches_path(q: category, model: 'categories'), class: "me-3" %>
+          <% end %>
+        </p>
       </div>
       <div class="gadget-detail">
         <p class="category">使用開始日</p>

--- a/app/views/gadgets/show.html.erb
+++ b/app/views/gadgets/show.html.erb
@@ -19,11 +19,11 @@
         </div>
       <% end %>
     </div>
-
-    <div class="gadget-image-lg">
-      <%= image_tag @gadget.image %>
-    </div>
-
+    <% if @gadget.image.present? %>
+      <div class="gadget-image-lg">
+        <%= image_tag @gadget.image %>
+      </div>
+    <% end %>
     <%# いいね %>
     <div class="likes d-flex fs-3" id="likes-<%= @gadget.id %>">
       <%= render partial: 'shared/likes_and_liked_users', locals: {gadget: @gadget} %>

--- a/app/views/gadgets/top.html.erb
+++ b/app/views/gadgets/top.html.erb
@@ -143,11 +143,13 @@
             <div class="gadget-image-sm">
               <div class="row">
                 <% user.gadgets.each do |gadget| %>
-                  <div class="col-3 my-2">
-                    <%= link_to gadget_path(gadget.id) do %>
-                      <%= image_tag gadget.image %>
-                    <% end %>
-                  </div>
+                  <% if gadget.image.present? %>
+                    <div class="col-3 my-2">
+                      <%= link_to gadget_path(gadget.id) do %>
+                        <%= image_tag gadget.image %>
+                      <% end %>
+                    </div>
+                  <% end %>
                 <% end %>
               </div>
             </div>

--- a/app/views/gadgets/top.html.erb
+++ b/app/views/gadgets/top.html.erb
@@ -78,13 +78,11 @@
                   </div>
                 <% end %>
                 <p class="gadget-name"><%= gadget.name %></p>
-
                 <p class="gadget-category">
                   <% gadget.category_list.each do |category| %>
                     <%= link_to category, searches_path(q: category, model: 'categories') %>
                   <% end %>
                 </p>
-                
                 <%# いいねとコメント %>
                 <div class="likes-and-comments-container d-flex fs-4">
                   <div class="likes" id="likes-<%= gadget.id %>">

--- a/app/views/gadgets/top.html.erb
+++ b/app/views/gadgets/top.html.erb
@@ -95,9 +95,11 @@
                   </div>
                 </div>
               </div>
-              <div class="gadget-image-md">
-                <%= image_tag gadget.image %>
-              </div>
+              <% if gadget.image.present? %>
+                <div class="gadget-image-md">
+                  <%= image_tag gadget.image %>
+                </div>
+              <% end %>
             </div>
             <div class="detail-link-container">
               <%= link_to "＞ 投稿詳細へ", gadget_path(gadget), class: "btn detail-link" %>

--- a/app/views/gadgets/top.html.erb
+++ b/app/views/gadgets/top.html.erb
@@ -78,7 +78,13 @@
                   </div>
                 <% end %>
                 <p class="gadget-name"><%= gadget.name %></p>
-                <p class="gadget-category"><%= gadget.category %></p>
+
+                <p class="gadget-category">
+                  <% gadget.category_list.each do |category| %>
+                    <%= link_to category, searches_path(q: category, model: 'categories') %>
+                  <% end %>
+                </p>
+                
                 <%# いいねとコメント %>
                 <div class="likes-and-comments-container d-flex fs-4">
                   <div class="likes" id="likes-<%= gadget.id %>">

--- a/app/views/searches/index.html.erb
+++ b/app/views/searches/index.html.erb
@@ -1,6 +1,6 @@
+<% content_for :title, "検索結果" %>
 <div class="container">
   <h2 class="search-title text-center mt-64">検索結果</h2>
-
   <%= form_with url: searches_path, method: :get, id: 'search-form', local: true, class: "mt-56" do |f| %>
     <div class="responsive-container-540">
       <div class="row">
@@ -14,7 +14,6 @@
       </div>
     </div>
   <% end %>
-
   <div class="row">
     <div class="col px-4 search-title-item">
       <%= link_to '投稿', searches_path(model: 'gadgets', q: params[:q]), id: 'gadget-link', class: (@model == 'gadgets' ? 'active-link' : 'inactive-link'), remote: true %>
@@ -26,7 +25,6 @@
       <%= link_to 'ユーザー', searches_path(model: 'users', q: params[:q]), id: 'user-link', class: (@model == 'users' ? 'active-link' : 'inactive-link'), remote: true %>
     </div>
   </div>
-
   <div id="search-result">
     <% if @gadgets.present? %>
       <%= render partial: 'shared/search_gadget_page', locals: { gadgets: @gadgets } %>

--- a/app/views/searches/index.html.erb
+++ b/app/views/searches/index.html.erb
@@ -20,6 +20,9 @@
       <%= link_to '投稿', searches_path(model: 'gadgets', q: params[:q]), id: 'gadget-link', class: (@model == 'gadgets' ? 'active-link' : 'inactive-link'), remote: true %>
     </div>
     <div class="col px-4 search-title-item">
+      <%= link_to 'カテゴリー', searches_path(model: 'categories', q: params[:q]), id: 'category-link', class: (@model == 'categories' ? 'active-link' : 'inactive-link'), remote: true %>
+    </div>
+    <div class="col px-4 search-title-item">
       <%= link_to 'ユーザー', searches_path(model: 'users', q: params[:q]), id: 'user-link', class: (@model == 'users' ? 'active-link' : 'inactive-link'), remote: true %>
     </div>
   </div>

--- a/app/views/searches/index.js.erb
+++ b/app/views/searches/index.js.erb
@@ -12,9 +12,12 @@ $('#search-result').empty();
 var model = "<%= @model %>";
 $('#gadget-link').removeClass('active-link').addClass('inactive-link');
 $('#user-link').removeClass('active-link').addClass('inactive-link');
+$('#category-link').removeClass('active-link').addClass('inactive-link');
 
 if (model === 'gadgets') {
   $('#gadget-link').removeClass('inactive-link').addClass('active-link');
 } else if (model === 'users') {
   $('#user-link').removeClass('inactive-link').addClass('active-link');
+} else if (model === 'categories') {
+  $('#category-link').removeClass('inactive-link').addClass('active-link');
 }

--- a/app/views/shared/_search_gadget_page.html.erb
+++ b/app/views/shared/_search_gadget_page.html.erb
@@ -34,9 +34,11 @@
                 </div>
               </div>
             </div>
-            <div class="gadget-image-md">
-              <%= image_tag gadget.image %>
-            </div>
+            <% if gadget.image.present? %>
+              <div class="gadget-image-md">
+                <%= image_tag gadget.image %>
+              </div>
+            <% end %>
           </div>
           <div class="detail-link-container">
             <%= link_to "＞ 投稿詳細へ", gadget_path(gadget), class: "btn detail-link" %>

--- a/app/views/shared/_search_gadget_page.html.erb
+++ b/app/views/shared/_search_gadget_page.html.erb
@@ -17,7 +17,11 @@
                 </div>
               <% end %>
               <p class="gadget-name"><%= gadget.name %></p>
-              <p class="gadget-category"><%= gadget.category %></p>
+              <p class="gadget-category">
+                <% gadget.category_list.each do |category| %>
+                  <%= link_to category, searches_path(q: category, model: 'categories') %>
+                <% end %>
+              </p>
               <%# いいねとコメント %>
               <div class="likes-and-comments-container d-flex fs-4">
                 <div class="likes" id="likes-<%= gadget.id %>">

--- a/app/views/shared/_search_user_page.html.erb
+++ b/app/views/shared/_search_user_page.html.erb
@@ -23,11 +23,13 @@
           <div class="gadget-image-sm">
             <div class="row">
               <% user.gadgets.each do |gadget| %>
-                <div class="col-3 my-2">
-                  <%= link_to gadget_path(gadget.id) do %>
-                    <%= image_tag gadget.image %>
-                  <% end %>
-                </div>
+                <% if gadget.image.present? %>
+                  <div class="col-3 my-2">
+                    <%= link_to gadget_path(gadget.id) do %>
+                      <%= image_tag gadget.image %>
+                    <% end %>
+                  </div>
+                <% end %>
               <% end %>
             </div>
           </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -29,11 +29,13 @@
             <div class="gadget-image-sm">
               <div class="row">
                 <% user.gadgets.each do |gadget| %>
-                  <div class="col-3 my-2">
-                    <%= link_to gadget_path(gadget.id) do %>
-                      <%= image_tag gadget.image %>
-                    <% end %>
-                  </div>
+                  <% if gadget.image.present? %>
+                    <div class="col-3 my-2">
+                      <%= link_to gadget_path(gadget.id) do %>
+                        <%= image_tag gadget.image %>
+                      <% end %>
+                    </div>
+                  <% end %>
                 <% end %>
               </div>
             </div>

--- a/app/views/users/show_favorites.html.erb
+++ b/app/views/users/show_favorites.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "#{@user.name}さんのお気にいりガジェット" %>
+<% content_for :title, "#{@user.name}さんのお気に入りガジェット" %>
 <div class="container mt-5">
   <div class="responsive-container-720">
     <div class="user-info-and-link-profile">
@@ -39,7 +39,6 @@
         <% end %>
       </div>
     </div>
-
     <div class="mypage-link-lists row justify-content-center">
       <div class="col">
         <p class="link-page text-center"><%= link_to "My ガジェット", mygadgets_user_path(@user.id) %></p>
@@ -48,7 +47,6 @@
         <p class="current-page text-center"><span>お気に入り</span></p>
       </div>
     </div>
-
     <div class="lists">
       <% @gadgets.each do |gadget| %>
         <div class="list-item">
@@ -66,7 +64,11 @@
                 </div>
               <% end %>
               <p class="gadget-name"><%= gadget.name %></p>
-              <p class="gadget-category"><%= gadget.category %></p>
+              <p class="gadget-category">
+                <% gadget.category_list.each do |category| %>
+                  <%= link_to category, searches_path(q: category, model: 'categories') %>
+                <% end %>
+              </p>
               <%# いいねとコメント %>
               <div class="likes-and-comments-container d-flex fs-4">
                 <div class="likes" id="likes-<%= gadget.id %>">
@@ -79,9 +81,11 @@
                 </div>
               </div>
             </div>
-            <div class="gadget-image-md">
-              <%= image_tag gadget.image %>
-            </div>
+            <% if gadget.image.present? %>
+              <div class="gadget-image-md">
+                <%= image_tag gadget.image %>
+              </div>
+            <% end %>
           </div>
           <div class="detail-link-container">
             <%= link_to "＞ 投稿詳細へ", gadget_path(gadget), class: "btn detail-link" %>
@@ -89,7 +93,6 @@
         </div>
       <% end %>
     </div>
-
     <% if current_user == @user %>
       <div class="gadget-new-registration-btn-container">
         <%= link_to "＋新規登録", new_gadget_path, class: "btn gadget-new-registration-btn" %>

--- a/app/views/users/show_mygadgets.html.erb
+++ b/app/views/users/show_mygadgets.html.erb
@@ -39,7 +39,6 @@
         <% end %>
       </div>
     </div>
-
     <div class="mypage-link-lists row justify-content-center">
       <div class="col">
         <p class="current-page text-center"><span>My ガジェット</span></p>
@@ -48,16 +47,19 @@
         <p class="link-page text-center"><%= link_to "お気に入り", favorites_user_path(@user.id) %></p>
       </div>
     </div>
-
     <div class="mygadget-lists">
-      <% @gadgets.group_by(&:category).each do |category, gadgets| %>
+      <%# １ガジェットに複数カテゴリーの場合でも１カテゴリー毎に表示 %>
+      <% category_gadgets = @gadgets.flat_map { |gadget| gadget.category_list.map { |category| [category, gadget] } }.group_by(&:first) %>
+      <% category_gadgets.each do |category, gadgets_with_category| %>
         <div class="category-container">
           <h4><%= category %></h4>
-          <% gadgets.each do |gadget| %>
+          <% gadgets_with_category.each do |_, gadget| %>
             <div class="mygadget-detail mt-4">
-              <div class="gadget-image" >
-                <%= image_tag gadget.image %>
-              </div>
+              <% if gadget.image.present? %>
+                <div class="gadget-image" >
+                  <%= image_tag gadget.image %>
+                </div>
+              <% end %>
               <div class="gadget-name">
                 <h5><%= gadget.name %></h5>
               </div>
@@ -80,7 +82,6 @@
         </div>
       <% end %>
     </div>
-
     <% if current_user == @user %>
       <div class="gadget-new-registration-btn-container">
         <%= link_to "＋新規登録", new_gadget_path, class: "btn gadget-new-registration-btn" %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -14,13 +14,13 @@ ja:
         current_password: '現在のパスワード'
         remember_me: 'ログイン状態を保持する'
       gadget:
-        category: 'カテゴリー'
         start_date: '使用開始日'
         feature: 'ガジェットの特徴'
         point: '推しポイント'
         reason: '選んだ理由'
         usage: '使用用途'
         name: 'ガジェット名'
+        category_list: "カテゴリー"
     errors:
       messages:
         taken: "はすでに使用されています"

--- a/db/migrate/20230527011659_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20230527011659_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+# This migration comes from acts_as_taggable_on_engine (originally 1)
+
+class ActsAsTaggableOnMigration < ActiveRecord::Migration[6.0]
+  def self.up
+    create_table ActsAsTaggableOn.tags_table do |t|
+      t.string :name
+      t.timestamps
+    end
+
+    create_table ActsAsTaggableOn.taggings_table do |t|
+      t.references :tag, foreign_key: { to_table: ActsAsTaggableOn.tags_table }
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
+
+      # Limit is created to prevent MySQL error on index
+      # length for MyISAM table type: http://bit.ly/vgW2Ql
+      t.string :context, limit: 128
+
+      t.datetime :created_at
+    end
+
+    add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context],
+              name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    drop_table ActsAsTaggableOn.taggings_table
+    drop_table ActsAsTaggableOn.tags_table
+  end
+end

--- a/db/migrate/20230527011660_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20230527011660_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+# This migration comes from acts_as_taggable_on_engine (originally 2)
+
+class AddMissingUniqueIndices < ActiveRecord::Migration[6.0]
+  def self.up
+    add_index ActsAsTaggableOn.tags_table, :name, unique: true
+
+    remove_index ActsAsTaggableOn.taggings_table, :tag_id if index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+    add_index ActsAsTaggableOn.taggings_table,
+              %i[tag_id taggable_id taggable_type context tagger_id tagger_type],
+              unique: true, name: 'taggings_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.tags_table, :name
+
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_idx'
+
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context],
+              name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20230527011661_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20230527011661_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+# This migration comes from acts_as_taggable_on_engine (originally 3)
+
+class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[6.0]
+  def self.up
+    add_column ActsAsTaggableOn.tags_table, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, ActsAsTaggableOn.taggings_table)
+    end
+  end
+
+  def self.down
+    remove_column ActsAsTaggableOn.tags_table, :taggings_count
+  end
+end

--- a/db/migrate/20230527011662_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20230527011662_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+# This migration comes from acts_as_taggable_on_engine (originally 4)
+
+class AddMissingTaggableIndex < ActiveRecord::Migration[6.0]
+  def self.up
+    add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context],
+              name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20230527011663_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20230527011663_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+# This migration comes from acts_as_taggable_on_engine (originally 5)
+
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+
+class ChangeCollationForTagNames < ActiveRecord::Migration[6.0]
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE #{ActsAsTaggableOn.tags_table} MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end

--- a/db/migrate/20230527011664_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20230527011664_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+# This migration comes from acts_as_taggable_on_engine (originally 6)
+
+class AddMissingIndexesOnTaggings < ActiveRecord::Migration[6.0]
+  def change
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists? ActsAsTaggableOn.taggings_table, :tag_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_id unless index_exists? ActsAsTaggableOn.taggings_table,
+                                                                                 :taggable_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_type unless index_exists? ActsAsTaggableOn.taggings_table,
+                                                                                   :taggable_type
+    add_index ActsAsTaggableOn.taggings_table, :tagger_id unless index_exists? ActsAsTaggableOn.taggings_table,
+                                                                               :tagger_id
+    add_index ActsAsTaggableOn.taggings_table, :context unless index_exists? ActsAsTaggableOn.taggings_table, :context
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, %i[tagger_id tagger_type]
+      add_index ActsAsTaggableOn.taggings_table, %i[tagger_id tagger_type]
+    end
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type tagger_id context],
+                         name: 'taggings_idy'
+      add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type tagger_id context],
+                name: 'taggings_idy'
+    end
+  end
+end

--- a/db/migrate/20230527011665_add_tenant_to_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20230527011665_add_tenant_to_taggings.acts_as_taggable_on_engine.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+# This migration comes from acts_as_taggable_on_engine (originally 7)
+
+class AddTenantToTaggings < ActiveRecord::Migration[6.0]
+  def self.up
+    add_column ActsAsTaggableOn.taggings_table, :tenant, :string, limit: 128
+    add_index ActsAsTaggableOn.taggings_table, :tenant unless index_exists? ActsAsTaggableOn.taggings_table, :tenant
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.taggings_table, :tenant
+    remove_column ActsAsTaggableOn.taggings_table, :tenant
+  end
+end

--- a/db/migrate/20230527015715_convert_categories_to_tags.rb
+++ b/db/migrate/20230527015715_convert_categories_to_tags.rb
@@ -1,0 +1,12 @@
+class ConvertCategoriesToTags < ActiveRecord::Migration[6.1]
+  class Gadget < ApplicationRecord
+    acts_as_taggable_on :categories
+  end
+
+  def up
+    Gadget.find_each do |gadget|
+      gadget.category_list = gadget.category
+      gadget.save
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_01_004156) do
+ActiveRecord::Schema.define(version: 2023_05_27_011665) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,13 +37,13 @@ ActiveRecord::Schema.define(version: 2023_05_01_004156) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table "active_storage_variant_records", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "active_storage_variant_records", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
-  create_table "comments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "comments", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "gadget_id", null: false
     t.text "content", null: false
@@ -66,7 +66,7 @@ ActiveRecord::Schema.define(version: 2023_05_01_004156) do
     t.index ["user_id"], name: "index_gadgets_on_user_id"
   end
 
-  create_table "likes", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "likes", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "gadget_id", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -84,6 +84,37 @@ ActiveRecord::Schema.define(version: 2023_05_01_004156) do
     t.index ["followed_id"], name: "index_relationships_on_followed_id"
     t.index ["follower_id", "followed_id"], name: "index_relationships_on_follower_id_and_followed_id", unique: true
     t.index ["follower_id"], name: "index_relationships_on_follower_id"
+  end
+
+  create_table "taggings", force: :cascade do |t|
+    t.bigint "tag_id"
+    t.string "taggable_type"
+    t.bigint "taggable_id"
+    t.string "tagger_type"
+    t.bigint "tagger_id"
+    t.string "context", limit: 128
+    t.datetime "created_at"
+    t.string "tenant", limit: 128
+    t.index ["context"], name: "index_taggings_on_context"
+    t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+    t.index ["taggable_id", "taggable_type", "context"], name: "taggings_taggable_context_idx"
+    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy"
+    t.index ["taggable_id"], name: "index_taggings_on_taggable_id"
+    t.index ["taggable_type", "taggable_id"], name: "index_taggings_on_taggable_type_and_taggable_id"
+    t.index ["taggable_type"], name: "index_taggings_on_taggable_type"
+    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type"
+    t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
+    t.index ["tagger_type", "tagger_id"], name: "index_taggings_on_tagger_type_and_tagger_id"
+    t.index ["tenant"], name: "index_taggings_on_tenant"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.integer "taggings_count", default: 0
+    t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
   create_table "users", force: :cascade do |t|
@@ -116,4 +147,5 @@ ActiveRecord::Schema.define(version: 2023_05_01_004156) do
   add_foreign_key "gadgets", "users"
   add_foreign_key "likes", "gadgets"
   add_foreign_key "likes", "users"
+  add_foreign_key "taggings", "tags"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_27_011665) do
+ActiveRecord::Schema.define(version: 2023_05_27_015715) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/system/searches/index_spec.rb
+++ b/spec/system/searches/index_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe "Searches", type: :system do
   let!(:user1) { create(:user, name: '山田太郎', introduction: 'おはようございます') }
   let!(:user2) { create(:user, name: '田中太郎', introduction: 'こんにちは') }
   let!(:user3) { create(:user, name: '山田花子', introduction: 'こんばんは') }
-  let!(:gadget1) { create(:gadget, name: 'iPhone14 Pro Max', reason: 'Appleが好きだからです', usage: 'メインスマホとして使用しています', point: '画面が大きくて使いやすいです') }
-  let!(:gadget2) { create(:gadget, name: 'iPhone13 mini', reason: 'Appleが好きだからです', usage: 'サブスマホとして使用しています', point: '画面が小さくてコンパクトです') }
-  let!(:gadget3) { create(:gadget, name: 'Pixel Fold', reason: 'Googleが好きだからです', usage: 'メインスマホとして使用しています', point: 'カメラが綺麗です') }
+  let!(:gadget1) { create(:gadget, name: 'iPhone14 Pro Max', reason: 'Appleが好きだからです', usage: 'メインスマホとして使用しています', point: '画面が大きくて使いやすいです', category_list: 'メインスマホ') }
+  let!(:gadget2) { create(:gadget, name: 'iPhone13 mini', reason: 'Appleが好きだからです', usage: 'サブスマホとして使用しています', point: '画面が小さくてコンパクトです', category_list: 'サブスマホ') }
+  let!(:gadget3) { create(:gadget, name: 'Pixel Fold', reason: 'Googleが好きだからです', usage: 'メインスマホとして使用しています', point: 'カメラが綺麗です', category_list: 'メインスマホ') }
 
   it '検索キーワードとガジェット名が部分一致するガジェットが”投稿”タブに表示される（一致しないガジェットが表示されていない）' do
     visit searches_path
@@ -49,6 +49,18 @@ RSpec.describe "Searches", type: :system do
       expect(page).to have_content(gadget1.name)
       expect(page).not_to have_content(gadget2.name)
       expect(page).not_to have_content(gadget3.name)
+    end
+  end
+
+  it '検索キーワードとカテゴリー名が完全一致するガジェットが”カテゴリー”タブに表示される（一致しないガジェットが表示されていない）', js: true do
+    visit searches_path
+    fill_in 'q', with: 'メインスマホ'
+    click_button '検索'
+    click_link 'カテゴリー'
+    within('#search-result') do
+      expect(page).to have_content(gadget1.name)
+      expect(page).not_to have_content(gadget2.name)
+      expect(page).to have_content(gadget3.name)
     end
   end
 
@@ -95,6 +107,7 @@ RSpec.describe "Searches", type: :system do
     end
     expect(page).to have_css('#gadget-link.inactive-link')
     expect(page).to have_css('#user-link.active-link')
+    expect(page).to have_css('#category-link.inactive-link')
   end
 
   it 'トップページの検索欄で未入力のまま検索ボタン押下後、検索結果ページにて投稿タブが太字、下線ありの装飾が適用されている' do
@@ -102,5 +115,20 @@ RSpec.describe "Searches", type: :system do
     click_button '検索'
     expect(page).to have_css('#gadget-link.active-link')
     expect(page).to have_css('#user-link.inactive-link')
+    expect(page).to have_css('#category-link.inactive-link')
+  end
+
+  it 'トップページの新着投稿欄のカテゴリータグをクリックすると検索結果ページのカテゴリータブに遷移し、選択したカテゴリーと同一カテゴリーの投稿一覧が表示される', js: true do
+    visit root_path
+    click_link 'メインスマホ', match: :first
+    expect(page).to have_title('検索結果')
+    expect(page).to have_css('#gadget-link.inactive-link')
+    expect(page).to have_css('#user-link.inactive-link')
+    expect(page).to have_css('#category-link.active-link')
+    within('#search-result') do
+      expect(page).to have_content(gadget1.name)
+      expect(page).not_to have_content(gadget2.name)
+      expect(page).to have_content(gadget3.name)
+    end
   end
 end


### PR DESCRIPTION
#193 
【実装機能概要】
- gem: acts-as-taggable-onの追加
- トップページ／新着投稿一覧／ガジェット詳細／コメント一覧／マイページ（お気に入り）／検索結果ページのガジェット一覧のカテゴリーをクリックするとそのカテゴリーの一覧に遷できるように
- レスポンシブ対応
- ガジェット新規登録のフォームにtagを追加
- 検索結果ページにタイトルを追加
- テスト実装