### PR TITLE
楽天APIの設定 #194

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,9 @@ gem 'meta-tags'
 gem 'ransack'
 # タグ付け機能
 gem 'acts-as-taggable-on'
+# 楽天API
+gem 'rakuten_web_service'
+
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,7 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     jmespath (1.6.2)
+    json (2.6.3)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.2)
@@ -230,6 +231,8 @@ GEM
       rake (>= 12.2)
       thor (~> 1.0)
     rake (13.0.6)
+    rakuten_web_service (1.13.2)
+      json (~> 2.3)
     ransack (4.0.0)
       activerecord (>= 6.1.5)
       activesupport (>= 6.1.5)
@@ -345,6 +348,7 @@ DEPENDENCIES
   rails (~> 6.1.7, >= 6.1.7.2)
   rails-erd
   rails-i18n
+  rakuten_web_service
   ransack
   rspec-rails
   sass-rails (>= 6)

--- a/app/assets/stylesheets/base/_typography.scss
+++ b/app/assets/stylesheets/base/_typography.scss
@@ -59,3 +59,7 @@ p {
 .mt-120 {
   margin-top: 120px;
 }
+
+.w100 {
+  width: 100%;
+}

--- a/app/assets/stylesheets/gadgets/_new.scss
+++ b/app/assets/stylesheets/gadgets/_new.scss
@@ -1,3 +1,7 @@
+#rakuten_url_text {
+  word-wrap: break-word;
+}
+
 .link-delete-btn {
   display: none;
 }

--- a/app/assets/stylesheets/gadgets/_new.scss
+++ b/app/assets/stylesheets/gadgets/_new.scss
@@ -1,2 +1,3 @@
-// @import "components/forms";
-// @import "components/buttons";
+.link-delete-btn {
+  display: none;
+}

--- a/app/controllers/gadgets_controller.rb
+++ b/app/controllers/gadgets_controller.rb
@@ -58,6 +58,15 @@ class GadgetsController < ApplicationController
     @users = User.joins(:likes).where(likes: { gadget_id: @gadget.id }).order('likes.created_at DESC').page(params[:page])
   end
 
+  def search_rakuten
+    if params[:q].present?
+      @rakuten_items = RakutenWebService::Ichiba::Item.search(keyword: params[:q])
+    end
+    respond_to do |format|
+      format.js
+    end
+  end
+
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_gadget
@@ -66,7 +75,7 @@ class GadgetsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def gadget_params
-      params.require(:gadget).permit(:user_id, :name, :start_date, :category_list, :reason, :point, :usage, :image).merge(user_id:current_user.id)
+      params.require(:gadget).permit(:user_id, :name, :start_date, :category_list, :reason, :point, :usage, :image, :rakuten_url).merge(user_id:current_user.id)
     end
 
     def ensure_correct_user

--- a/app/controllers/gadgets_controller.rb
+++ b/app/controllers/gadgets_controller.rb
@@ -48,7 +48,7 @@ class GadgetsController < ApplicationController
     flash[:notice] = "ガジェットを削除しました"
     @gadget.destroy
     respond_to do |format|
-      format.html { redirect_to gadgets_url, notice: "Gadget was successfully destroyed." }
+      format.html { redirect_to mygadgets_user_path(current_user.id), notice: "ガジェットを削除しました" }
       format.json { head :no_content }
     end
   end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -119,9 +119,6 @@ $(document).on('click', '.rakuten-add-button', function(e) {
   // 削除ボタンを表示
   $('#remove_rakuten_url_button').show();
 
-  // 選択されたURLをLocalStorageに保存
-  localStorage.setItem('selectedRakutenUrl', selectedRakutenUrl);
-
   // モーダルウィンドウを閉じる
   $('#rakuten-modal').modal('hide');
 });
@@ -135,9 +132,6 @@ $(document).on('click', '#remove_rakuten_url_button', function(e) {
 
   // hidden_field の値も空にする
   $('#gadget_rakuten_url').val('');
-
-  // localStorageの値も削除する
-  localStorage.removeItem('selectedRakutenUrl');
 
   // 削除ボタンを非表示にする
   $(this).hide();

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -103,7 +103,7 @@ $(document).on('turbolinks:load', function() {
   });
 });
 
-  // モーダルウィンドウ内の"追加"ボタンがクリックされたときの処理
+// モーダルウィンドウ内の"追加"ボタンがクリックされたときの処理
 $(document).on('click', '.rakuten-add-button', function(e) {
   e.preventDefault();
 
@@ -126,7 +126,7 @@ $(document).on('click', '.rakuten-add-button', function(e) {
   $('#rakuten-modal').modal('hide');
 });
 
-  // 削除ボタンをクリックした時の処理
+// 削除ボタンをクリックした時の処理
 $(document).on('click', '#remove_rakuten_url_button', function(e) {
   e.preventDefault();
 
@@ -141,4 +141,13 @@ $(document).on('click', '#remove_rakuten_url_button', function(e) {
 
   // 削除ボタンを非表示にする
   $(this).hide();
+});
+
+// ガジェット編集ページ表示時に、楽天URLが設定されている場合に削除ボタンを表示する
+$(document).on('turbolinks:load', function() {
+  var selectedRakutenUrl = $('#gadget_rakuten_url').val()
+
+  if (selectedRakutenUrl && selectedRakutenUrl !== 'なし') {
+    $('#remove_rakuten_url_button').show();
+  }
 });

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -92,3 +92,53 @@ $(document).on('turbolinks:load', function() {
   });
 });
 
+// 楽天URL検索ページのモーダルウィンドウ
+$(document).on('turbolinks:load', function() {
+  // ”楽天のリンクを追加する”ボタンをクリックしたときの処理
+  $(document).on('click', '#rakuten-link-button', function(e) {
+    e.preventDefault();
+
+    // モーダルウィンドウを表示
+    $('#rakuten-modal').modal('show');
+  });
+});
+
+  // モーダルウィンドウ内の"追加"ボタンがクリックされたときの処理
+$(document).on('click', '.rakuten-add-button', function(e) {
+  e.preventDefault();
+
+  // data-url 属性から楽天URLを取得
+  var selectedRakutenUrl = $(this).data('url');
+
+  // hidden_field に選択した楽天URLを設定
+  $('#gadget_rakuten_url').val(selectedRakutenUrl);
+
+  // "選択された楽天リンク"表示部分にURLを表示
+  $('#rakuten_url_text').text(selectedRakutenUrl);
+
+  // 削除ボタンを表示
+  $('#remove_rakuten_url_button').show();
+
+  // 選択されたURLをLocalStorageに保存
+  localStorage.setItem('selectedRakutenUrl', selectedRakutenUrl);
+
+  // モーダルウィンドウを閉じる
+  $('#rakuten-modal').modal('hide');
+});
+
+  // 削除ボタンをクリックした時の処理
+$(document).on('click', '#remove_rakuten_url_button', function(e) {
+  e.preventDefault();
+
+  // "選択された楽天リンク"表示部分を "なし" に戻す
+  $('#rakuten_url_text').text('なし');
+
+  // hidden_field の値も空にする
+  $('#gadget_rakuten_url').val('');
+
+  // localStorageの値も削除する
+  localStorage.removeItem('selectedRakutenUrl');
+
+  // 削除ボタンを非表示にする
+  $(this).hide();
+});

--- a/app/javascript/stylesheets/_custom.scss
+++ b/app/javascript/stylesheets/_custom.scss
@@ -3,3 +3,4 @@ $primary: #EEEEEE;
 $secondary: #929AAB;
 $dark: #393E46;
 $info: #679EF1;
+$success: #FFFFFF;

--- a/app/javascript/stylesheets/_custom.scss
+++ b/app/javascript/stylesheets/_custom.scss
@@ -4,3 +4,4 @@ $secondary: #929AAB;
 $dark: #393E46;
 $info: #679EF1;
 $success: #FFFFFF;
+$danger: #bf0000;

--- a/app/views/gadgets/edit.html.erb
+++ b/app/views/gadgets/edit.html.erb
@@ -2,9 +2,8 @@
 <div class="container mt-80">
   <div class="responsive-container-540">
     <h2 class="form-title">ガジェットを編集</h2>
-
     <%= form_with model: @gadget, url: gadget_path, local: true do |f| %>
-     <%= render "devise/shared/error_messages", resource: @gadget %>
+      <%= render "devise/shared/error_messages", resource: @gadget %>
       <div class="field mb-5">
         <div class="label-container">
           <%= f.label :name, "ガジェット名", class: "form-label" %>
@@ -50,6 +49,24 @@
         </div>
         <%= f.text_area :usage, class: "form-control", rows: 8 %>
       </div>
+      <div class="field mb-5 mt-48">
+        <div class="label-container">
+          <%= f.label :rakuten_url, "楽天のリンクを設定", class: "form-label" %>
+        </div>
+        <div class="ps-2 mt-3">
+          <%= link_to "楽天のリンクを追加する", "#", id: "rakuten-link-button", local: true, class: "btn btn-success btn-outline-dark fs-5" %><br>
+          <p class="mt-3 fs-5">選択された楽天リンク</p>
+          <%= f.hidden_field :rakuten_url, id: "gadget_rakuten_url", value: @gadget.rakuten_url %>
+          <div class="row">
+            <div class="col-10">
+              <p class="fs-5 ps-3" id="rakuten_url_text"><%= @gadget.rakuten_url || 'なし' %></p>
+            </div>
+            <div class="col-2 d-flex justify-content-center align-items-center">
+              <button class="btn btn-primary btn-outline-dark fs-5 link-delete-btn" id="remove_rakuten_url_button">削除</button>
+            </div>
+          </div>
+        </div>
+      </div>
       <div class="actions mb-3 pt-4 d-grid mx-auto">
         <%= f.submit "更新", class: "btn" %>
       </div>
@@ -57,7 +74,6 @@
     <div class="d-grid">
       <%= link_to "キャンセル", :back, class: "btn btn-outline-dark mt-5 fs-3 py-2" %>
     </div>
-
     <div class="text-center mt-56">
       <button type="button" class="delete-button text-info border-0 bg-light fs-4" data-bs-toggle="modal" data-bs-target="#deleteGadgetModal">
         ガジェットを削除する
@@ -81,6 +97,35 @@
         <%= form_with model: @gadget, url: gadget_path, method: :delete, local: true, class: "d-inline" do |f| %>
           <%= f.submit "ガジェットを削除する", class: "btn btn-danger text-light fs-5" %>
         <% end %>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- 楽天商品検索モーダルウィンドウ -->
+<div class="modal fade" id="rakuten-modal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-xl">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h1 class="modal-title">楽天で商品を検索</h1>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>
+      </div>
+      <div class="mt-5">
+        <%= form_with url: search_rakuten_gadgets_path, method: :get, local: false, class: "row justify-content-center" do |f| %>
+          <div class="col-8">
+            <%= f.text_field :q, value: params[:q], class: "form-control form-control-lg" %>
+          </div>
+          <div class="col-1 d-grid">
+            <%= f.submit "検索", class: "btn btn-dark text-light fs-5" %>
+          </div>
+        <% end %>
+      </div>
+      <div class="modal-body" id="rakuten_result">
+        <!-- ここに楽天URL検索のUIを実装 -->
+        <%= render partial: 'shared/search_rakuten', locals: { rakuten_items: @rakuten_items } %>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-light btn-outline-dark" data-bs-dismiss="modal">キャンセル</button>
       </div>
     </div>
   </div>

--- a/app/views/gadgets/new.html.erb
+++ b/app/views/gadgets/new.html.erb
@@ -50,7 +50,6 @@
         </div>
         <%= f.text_area :usage, class: "form-control", rows: 8 %>
       </div>
-
       <div class="field mb-5 mt-48">
         <div class="label-container">
           <%= f.label :rakuten_url, "楽天のリンクを設定", class: "form-label" %>
@@ -58,7 +57,7 @@
         <div class="ps-2 mt-3">
           <%= link_to "楽天のリンクを追加する", "#", id: "rakuten-link-button", local: true, class: "btn btn-success btn-outline-dark fs-5" %><br>
           <p class="mt-3 fs-5">選択された楽天リンク</p>
-          <%= f.hidden_field :rakuten_url, id: "gadget_rakuten_url", value: @rakuten_url %>
+          <%= f.hidden_field :rakuten_url, id: "gadget_rakuten_url" %>
           <div class="row">
             <div class="col-10">
               <p class="fs-5 ps-3" id="rakuten_url_text">なし</p>
@@ -69,16 +68,14 @@
           </div>
         </div>
       </div>
-
       <div class="actions mb-3 pt-4 d-grid mx-auto">
         <%= f.submit "登録", class: "btn" %>
       </div>
     <% end %>
-
   </div>
 </div>
 
-<!-- モーダルウィンドウ -->
+<!-- 楽天商品検索モーダルウィンドウ -->
 <div class="modal fade" id="rakuten-modal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog modal-xl">
     <div class="modal-content">

--- a/app/views/gadgets/new.html.erb
+++ b/app/views/gadgets/new.html.erb
@@ -51,9 +51,58 @@
         <%= f.text_area :usage, class: "form-control", rows: 8 %>
       </div>
 
+      <div class="field mb-5 mt-48">
+        <div class="label-container">
+          <%= f.label :rakuten_url, "楽天のリンクを設定", class: "form-label" %>
+        </div>
+        <div class="ps-2 mt-3">
+          <%= link_to "楽天のリンクを追加する", "#", id: "rakuten-link-button", local: true, class: "btn btn-success btn-outline-dark fs-5" %><br>
+          <p class="mt-3 fs-5">選択された楽天リンク</p>
+          <%= f.hidden_field :rakuten_url, id: "gadget_rakuten_url", value: @rakuten_url %>
+          <div class="row">
+            <div class="col-10">
+              <p class="fs-5 ps-3" id="rakuten_url_text">なし</p>
+            </div>
+            <div class="col-2 d-flex justify-content-center align-items-center">
+              <button class="btn btn-primary btn-outline-dark fs-5 link-delete-btn" id="remove_rakuten_url_button">削除</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
       <div class="actions mb-3 pt-4 d-grid mx-auto">
         <%= f.submit "登録", class: "btn" %>
       </div>
     <% end %>
+
+  </div>
+</div>
+
+<!-- モーダルウィンドウ -->
+<div class="modal fade" id="rakuten-modal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-xl">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h1 class="modal-title">楽天で商品を検索</h1>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>
+      </div>
+      <div>
+        <%= form_with url: search_rakuten_gadgets_path, method: :get, local: false, class: "row justify-content-center" do |f| %>
+          <div class="col-8">
+            <%= f.text_field :q, value: params[:q], class: "form-control form-control-lg" %>
+          </div>
+          <div class="col-1 d-grid">
+            <%= f.submit "検索", class: "btn btn-dark text-light fs-5" %>
+          </div>
+        <% end %>
+      </div>
+      <div class="modal-body" id="rakuten_result">
+        <!-- ここに楽天URL検索のUIを実装 -->
+        <%= render partial: 'shared/search_rakuten', locals: { rakuten_items: @rakuten_items } %>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">キャンセル</button>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/views/gadgets/new.html.erb
+++ b/app/views/gadgets/new.html.erb
@@ -86,7 +86,7 @@
         <h1 class="modal-title">楽天で商品を検索</h1>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>
       </div>
-      <div>
+      <div class="mt-5">
         <%= form_with url: search_rakuten_gadgets_path, method: :get, local: false, class: "row justify-content-center" do |f| %>
           <div class="col-8">
             <%= f.text_field :q, value: params[:q], class: "form-control form-control-lg" %>
@@ -101,7 +101,7 @@
         <%= render partial: 'shared/search_rakuten', locals: { rakuten_items: @rakuten_items } %>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">キャンセル</button>
+        <button type="button" class="btn btn-light btn-outline-dark" data-bs-dismiss="modal">キャンセル</button>
       </div>
     </div>
   </div>

--- a/app/views/gadgets/search_rakuten.js.erb
+++ b/app/views/gadgets/search_rakuten.js.erb
@@ -1,0 +1,7 @@
+$('#rakuten_result').empty();
+
+<% if @rakuten_items.present? %>
+  $('#rakuten_result').html('<%= escape_javascript(render partial: 'shared/search_rakuten', locals: { rakuten_items: @rakuten_items }) %>');
+<% else %>
+  $('#rakuten_result').html('<p class="text-center fs-4">条件に一致する検索結果はありません。</p>');
+<% end %>

--- a/app/views/gadgets/show.html.erb
+++ b/app/views/gadgets/show.html.erb
@@ -58,6 +58,11 @@
         <p class="category">選んだ理由</p>
         <P class="content"><%= safe_join(@gadget.reason&.split("\n") || [], tag(:br)) %></P>
       </div>
+      <div class="gadget-detail mt-5 d-grid col-8 mx-auto">
+        <%= link_to @gadget.rakuten_url, class: "btn btn-danger fs-4" do %>
+          <span class="text-light">楽天で購入する</span><i class="fa-solid fa-arrow-up-right-from-square ms-2" style="color: #f7f7f7;"></i>
+        <% end %>
+      </div>
     </div>
 
     <% if current_user && @gadget.user_id == current_user.id %>

--- a/app/views/gadgets/show.html.erb
+++ b/app/views/gadgets/show.html.erb
@@ -58,11 +58,13 @@
         <p class="category">選んだ理由</p>
         <P class="content"><%= safe_join(@gadget.reason&.split("\n") || [], tag(:br)) %></P>
       </div>
-      <div class="gadget-detail mt-5 d-grid col-8 mx-auto">
-        <%= link_to @gadget.rakuten_url, class: "btn btn-danger fs-4" do %>
-          <span class="text-light">楽天で購入する</span><i class="fa-solid fa-arrow-up-right-from-square ms-2" style="color: #f7f7f7;"></i>
-        <% end %>
-      </div>
+      <% if @gadget.rakuten_url.present? %>
+        <div class="gadget-detail mt-5 d-grid col-8 mx-auto">
+          <%= link_to @gadget.rakuten_url, class: "btn btn-danger fs-4" do %>
+            <span class="text-light">楽天で購入する</span><i class="fa-solid fa-arrow-up-right-from-square ms-2" style="color: #f7f7f7;"></i>
+          <% end %>
+        </div>
+      <% end %>
     </div>
 
     <% if current_user && @gadget.user_id == current_user.id %>

--- a/app/views/shared/_search_rakuten.html.erb
+++ b/app/views/shared/_search_rakuten.html.erb
@@ -1,0 +1,24 @@
+<% if rakuten_items %>
+  <div class="mt-56">
+    <div class="row justify-content-lg-center bg-light border-bottom pb-2 fs-3 d-none d-sm-flex">
+      <div class="col-sm-5 col-lg-6 fw-bold text-center">商品名</div>
+      <div class="col-sm-3 col-lg-1 fw-bold text-center">商品画像</div>
+      <div class="col-sm-2 col-lg-1 fw-bold text-center">URL</div>
+      <div class="col-sm-2 col-lg-2 fw-bold text-center">リンクを選択</div>
+    </div>
+    <% if rakuten_items.count == 0 %>
+      <p class="text-center fs-4">条件に一致する検索結果はありません。</p>
+    <% else %>
+      <% rakuten_items.each do |rakuten_item| %>
+        <div class="row row-cols-2 g-3 justify-content-lg-center border-bottom py-4 fs-4">
+          <div class="col-9 col-sm-5 col-lg-6 d-flex align-items-center"><%= rakuten_item.name %></div>
+          <div class="col-3 col-sm-3 col-lg-1 d-flex align-items-center justify-content-center"><%= image_tag rakuten_item.small_image_urls.first, alt: rakuten_item.name %></div>
+          <div class="col col-sm-2 col-lg-1 d-flex align-items-center justify-content-center"><%= link_to "リンク", rakuten_item.url, class: "text-info", target: "_blank" %></div>
+          <div class="col col-sm-2 col-lg-2 d-flex align-items-center justify-content-center">
+            <%= link_to '選択', '#', data: { url: rakuten_item.url }, class: "btn btn-secondary btn-block text-light fs-4 rakuten-add-button" %>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/shared/_search_rakuten.html.erb
+++ b/app/views/shared/_search_rakuten.html.erb
@@ -7,7 +7,7 @@
       <div class="col-sm-2 col-lg-2 fw-bold text-center">リンクを選択</div>
     </div>
     <% if rakuten_items.count == 0 %>
-      <p class="text-center fs-4">条件に一致する検索結果はありません。</p>
+      <p class="text-center fs-4 mt-4 mb-3">条件に一致する検索結果はありません。</p>
     <% else %>
       <% rakuten_items.each do |rakuten_item| %>
         <div class="row row-cols-2 g-3 justify-content-lg-center border-bottom py-4 fs-4">

--- a/config/initializers/rakuten_web_service.rb
+++ b/config/initializers/rakuten_web_service.rb
@@ -1,0 +1,4 @@
+RakutenWebService.configure do |c|
+  c.application_id = ENV['RAKUTEN_APPLICATION_ID']
+  c.affiliate_id = ENV['RWS_AFFILIATION_ID']
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
   resources :gadgets do
     collection do
       get 'top'
+      # 楽天商品検索
+      get 'search_rakuten'
     end
     resource :likes, only: [:create, :destroy]
     get 'liked_users', on: :member

--- a/db/migrate/20230530072025_add_rakuten_url_to_gadgets.rb
+++ b/db/migrate/20230530072025_add_rakuten_url_to_gadgets.rb
@@ -1,0 +1,5 @@
+class AddRakutenUrlToGadgets < ActiveRecord::Migration[6.1]
+  def change
+    add_column :gadgets, :rakuten_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_27_015715) do
+ActiveRecord::Schema.define(version: 2023_05_30_072025) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -63,6 +63,7 @@ ActiveRecord::Schema.define(version: 2023_05_27_015715) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "rakuten_url"
     t.index ["user_id"], name: "index_gadgets_on_user_id"
   end
 

--- a/spec/factories/gadgets.rb
+++ b/spec/factories/gadgets.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :gadget do
     user
     name { Faker::Device.model_name }
-    category { Faker::Commerce.department(max: 1) }
+    category_list { Faker::Commerce.department(max: 1) }
     point { Faker::Lorem.sentence }
 
     # gadgetに画像を添付する

--- a/spec/system/gadgets/edit_spec.rb
+++ b/spec/system/gadgets/edit_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+RSpec.describe "Gadgets", type: :system do
+  let(:user) { create(:user) }
+  let!(:gadget1) { create(:gadget, user: user, rakuten_url: 'http://image_url1') }
+  let!(:gadget2) { create(:gadget, user: user) }
+
+  before do
+    allow(RakutenWebService::Ichiba::Item).to receive(:search).and_return(
+      [
+        double("RakutenItem", name: "iphone14 128GB", url: "http://test1.com", small_image_urls: ["http://image_url1"]),
+        double("RakutenItem", name: "iphone14 256GB", url: "http://test2.com", small_image_urls: ["http://image_url2"]),
+      ]
+    )
+  end
+
+  describe "rakuten_url" do
+    context "ガジェットのrakuten_urlに値が保存されている" do
+      before do
+        sign_in user
+        visit edit_gadget_path(gadget1.id)
+      end
+
+      it "選択された楽天リンク欄にDBに保存されているrakuten_urlと削除ボタンが表示されている", js: true do
+        expect(page).to have_selector("#rakuten_url_text", text: "http://image_url1")
+        expect(page).to have_field('gadget_rakuten_url', with: 'http://image_url1', type: 'hidden')
+        expect(page).to have_selector('#remove_rakuten_url_button')
+      end
+
+      it "選択された楽天リンク欄の削除ボタンをクリックすると、”選択された楽天リンク”欄が”なし”という表記に変わりhidden_fieldからも削除され、更新ボタンをクリックするとrakuten_urlカラムの値も削除される", js: true do
+        find('#remove_rakuten_url_button').click
+        expect(page).to have_selector("#rakuten_url_text", text: "なし")
+        expect(page).to have_field('gadget_rakuten_url', with: "", type: 'hidden')
+        click_on '更新'
+        gadget1.reload
+        expect(gadget1.rakuten_url).to eq ''
+      end
+
+      it "新たな楽天URLを選択し、更新ボタンをクリックすると新たに選択したURLがrakuten_urlとして保存される", js: true do
+        find('#rakuten-link-button').click
+        fill_in 'q', with: 'iphone14'
+        click_on '検索'
+        sleep 1
+        all('.rakuten-add-button')[1].click
+        expect(page).to have_selector("#rakuten_url_text", text: "http://test2.com")
+        expect(page).to have_field('gadget_rakuten_url', with: 'http://test2.com', type: 'hidden')
+        click_on '更新'
+        gadget1.reload
+        expect(gadget1.rakuten_url).to eq 'http://test2.com'
+      end
+    end
+
+    context "ガジェットのrakuten_urlに値が保存されていない" do
+      before do
+        sign_in user
+        visit edit_gadget_path(gadget2.id)
+      end
+
+      it "選択された楽天リンク欄に”なし”と表示されており、削除ボタンが表示されていない", js: true do
+        expect(page).to have_selector("#rakuten_url_text", text: "なし")
+        expect(page).to have_field('gadget_rakuten_url', with: '', type: 'hidden')
+        expect(page).to have_selector('#remove_rakuten_url_button', visible: false)
+      end
+
+      it "新たな楽天URLを選択し、更新ボタンをクリックすると新たに選択したURLがrakuten_urlとして保存される", js: true do
+        find('#rakuten-link-button').click
+        fill_in 'q', with: 'iphone14'
+        click_on '検索'
+        sleep 1
+        find('.rakuten-add-button', match: :first).click
+        expect(page).to have_selector("#rakuten_url_text", text: "http://test1.com")
+        expect(page).to have_field('gadget_rakuten_url', with: 'http://test1.com', type: 'hidden')
+        click_on '更新'
+        gadget2.reload
+        expect(gadget2.rakuten_url).to eq 'http://test1.com'
+      end
+    end
+  end
+end

--- a/spec/system/gadgets/new_spec.rb
+++ b/spec/system/gadgets/new_spec.rb
@@ -1,0 +1,101 @@
+require 'rails_helper'
+
+RSpec.describe "Gadgets", type: :system do
+  let(:user) { create(:user) }
+  # let(:gadget) { create(:gadget, user: user) }
+
+  before do
+    sign_in user
+    visit new_gadget_path
+    allow(RakutenWebService::Ichiba::Item).to receive(:search).and_return(
+      [
+        double("RakutenItem", name: "iphone14 128GB", url: "http://test1.com", small_image_urls: ["http://image_url1"]),
+        double("RakutenItem", name: "iphone14 256GB", url: "http://test2.com", small_image_urls: ["http://image_url2"]),
+      ]
+    )
+  end
+
+  describe "rakuten_url" do
+    it "”楽天のリンクを追加する”リンクをクリックするとモーダルウィンドウが表示される", js: true do
+      expect(page).not_to have_selector('.modal-open')
+      find('#rakuten-link-button').click
+      expect(page).to have_selector('.modal-open')
+    end
+
+    it "検索結果の各商品のリンクをクリックすると別タブにて楽天市場の商品購入ページに遷移する", js: true do
+      find('#rakuten-link-button').click
+      fill_in 'q', with: 'iphone14'
+      click_on '検索'
+      click_link(href: 'http://test1.com')
+      switch_to_window(windows.last)
+      expect(current_url).to eq 'http://test1.com/'
+    end
+
+    it "検索結果の各商品の”選択”ボタンをクリックすると、モーダルが閉じ、その商品のURLが”選択された楽天リンク”欄に表示され、hidden_fieldにも代入される", js: true do
+      find('#rakuten-link-button').click
+      fill_in 'q', with: 'iphone14'
+      click_on '検索'
+      sleep 1
+      find('.rakuten-add-button', match: :first).click
+      expect(page).not_to have_css("#rakuten-modal.show")
+      expect(page).to have_selector("#rakuten_url_text", text: "http://test1.com")
+      expect(page).to have_field('gadget_rakuten_url', with: 'http://test1.com', type: 'hidden')
+    end
+
+    it "モダール内のキャンセルボタンをクリックすると、モーダルが閉じる", js: true do
+      find('#rakuten-link-button').click
+      sleep 1
+      click_on 'キャンセル'
+      expect(page).not_to have_css("#rakuten-modal.show")
+    end
+
+    it "選択された楽天リンク欄の削除ボタンをクリックすると、”選択された楽天リンク”欄が”なし”という表記に変わり、hidden_fieldからも削除される", js: true do
+      find('#rakuten-link-button').click
+      fill_in 'q', with: 'iphone14'
+      click_on '検索'
+      sleep 1
+      find('.rakuten-add-button', match: :first).click
+      expect(page).to have_selector("#rakuten_url_text", text: "http://test1.com")
+      expect(page).to have_field('gadget_rakuten_url', with: 'http://test1.com', type: 'hidden')
+      find('#remove_rakuten_url_button').click
+      expect(page).to have_selector("#rakuten_url_text", text: "なし")
+      expect(page).to have_field('gadget_rakuten_url', with: "", type: 'hidden')
+    end
+
+    it "選択された楽天リンク欄に選択したURLが表示された状態で登録ボタンをクリックするとgadgetsモデルのrakuten_urlカラムにデータが保存される（その他必須項目は入力されている状態）", js: true do
+      find('#rakuten-link-button').click
+      fill_in 'q', with: 'iphone14'
+      click_on '検索'
+      sleep 1
+      find('.rakuten-add-button', match: :first).click
+      fill_in 'gadget_name', with: 'iphone14'
+      fill_in 'gadget_category_list', with: 'スマホ'
+      fill_in 'gadget_point', with: 'This is a great gadget.'
+      click_button '登録'
+      expect(Gadget.last.rakuten_url).to eq 'http://test1.com'
+    end
+
+    it "楽天リンクを選択した状態で、再度楽天のリンクを追加するボタンをクリックし、異なる商品を選択した場合その選択した商品のURLに選択された楽天リンク欄もhidden_fieldも入れ替わる", js: true do
+      find('#rakuten-link-button').click
+      fill_in 'q', with: 'iphone14'
+      click_on '検索'
+      sleep 1
+      find('.rakuten-add-button', match: :first).click
+      expect(page).to have_selector("#rakuten_url_text", text: "http://test1.com")
+      expect(page).to have_field('gadget_rakuten_url', with: 'http://test1.com', type: 'hidden')
+      find('#rakuten-link-button').click
+      fill_in 'q', with: 'iphone14'
+      click_on '検索'
+      sleep 1
+      all('.rakuten-add-button')[1].click
+      expect(page).to have_selector("#rakuten_url_text", text: "http://test2.com")
+      expect(page).to have_field('gadget_rakuten_url', with: 'http://test2.com', type: 'hidden')
+    end
+
+    it "モーダル内の検索入力欄を空欄の状態で検索ボタンをクリックすると”条件に一致する検索結果はありません。”が表示される", js: true do
+      find('#rakuten-link-button').click
+      click_on '検索'
+      expect(page).to have_content("条件に一致する検索結果はありません。")
+    end
+  end
+end

--- a/spec/system/gadgets/new_spec.rb
+++ b/spec/system/gadgets/new_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe "Gadgets", type: :system do
   let(:user) { create(:user) }
-  # let(:gadget) { create(:gadget, user: user) }
 
   before do
     sign_in user


### PR DESCRIPTION
#194 
【実装機能概要】
- 楽天APIを使用して投稿したガジェットを楽天で購入できるように実装
- アフィリエイトIDを設定
- gadgets#newページに楽天URLを設定できるフォームを追加
  - 設定する楽天の商品ページを検索する画面をモーダルで表示
  - モーダル内で非同期通信で楽天商品を検索可能に
  - 削除ボタンのクリックにより楽天URLの削除をjavascriptで実装
- gadgets#editに、楽天リンクの編集項目を追加
  - 楽天URLが登録されているか否かにより削除ボタンの表示有無をjavascriptでコントロール
- gagdets#showに、楽天リンクボタンを表示
  - 楽天のリンクは別タブで開くように設定
- レスポンシブ対応
- テストの実装
  - gadgets#newの楽天APIに関するテストを実装
  - gadgets#editの楽天APIに関するテストを実装