### PR TITLE
並び替え機能の実装 #192

### DIFF
--- a/app/controllers/gadgets_controller.rb
+++ b/app/controllers/gadgets_controller.rb
@@ -4,12 +4,19 @@ class GadgetsController < ApplicationController
   before_action :ensure_correct_user, only: [:edit, :update, :destroy]
 
   def top
-    @gadgets = Gadget.all.order('created_at DESC').limit(10)
-    @users = User.all.order('created_at DESC').limit(10)
+    @gadgets = Gadget.all.order('created_at DESC').limit(9)
+    @users = User.all.order('created_at DESC').limit(9)
   end
 
   def index
-    @gadgets = Gadget.all.order('created_at DESC').page(params[:page])
+    @gadgets = Gadget.all.order('created_at DESC').page(params[:page]).per(24)
+    @gadgets_new_order = Gadget.all.order('created_at DESC').page(params[:page])
+    @gadgets_older_order = Gadget.all.order('created_at ASC').page(params[:page])
+    @gadgets_ranking_order = Gadget.left_joins(:likes).group(:id).order('COUNT(likes.id) DESC').page(params[:page])
+    @gadgets_name_asc_order = Gadget.order('name ASC').page(params[:page])
+    @gadgets_name_desc_order = Gadget.order('name DESC').page(params[:page])
+    @gadgets_category_asc_order = Gadget.order('category_list ASC').page(params[:page])
+    @gadgets_category_desc_order = Gadget.order('category_list DESC').page(params[:page])
   end
 
   def show
@@ -34,7 +41,6 @@ class GadgetsController < ApplicationController
     end
   end
 
-  # PATCH/PUT /gadgets/1 or /gadgets/1.json
   def update
     if @gadget.update(gadget_params)
       redirect_to gadget_url(@gadget), notice: "ガジェット情報を更新しました"
@@ -43,7 +49,6 @@ class GadgetsController < ApplicationController
     end
   end
 
-  # DELETE /gadgets/1 or /gadgets/1.json
   def destroy
     flash[:notice] = "ガジェットを削除しました"
     @gadget.destroy
@@ -68,12 +73,10 @@ class GadgetsController < ApplicationController
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
     def set_gadget
       @gadget = Gadget.find(params[:id])
     end
 
-    # Only allow a list of trusted parameters through.
     def gadget_params
       params.require(:gadget).permit(:user_id, :name, :start_date, :category_list, :reason, :point, :usage, :image, :rakuten_url).merge(user_id:current_user.id)
     end

--- a/app/controllers/gadgets_controller.rb
+++ b/app/controllers/gadgets_controller.rb
@@ -9,14 +9,27 @@ class GadgetsController < ApplicationController
   end
 
   def index
-    @gadgets = Gadget.all.order('created_at DESC').page(params[:page]).per(24)
-    @gadgets_new_order = Gadget.all.order('created_at DESC').page(params[:page])
-    @gadgets_older_order = Gadget.all.order('created_at ASC').page(params[:page])
-    @gadgets_ranking_order = Gadget.left_joins(:likes).group(:id).order('COUNT(likes.id) DESC').page(params[:page])
-    @gadgets_name_asc_order = Gadget.order('name ASC').page(params[:page])
-    @gadgets_name_desc_order = Gadget.order('name DESC').page(params[:page])
-    @gadgets_category_asc_order = Gadget.order('category_list ASC').page(params[:page])
-    @gadgets_category_desc_order = Gadget.order('category_list DESC').page(params[:page])
+    case params[:order]
+    when 'older'
+      @gadgets = Gadget.all.order('created_at ASC').page(params[:page]).per(24)
+    when 'ranking'
+      @gadgets = Gadget.left_joins(:likes).group(:id).order('COUNT(likes.id) DESC').page(params[:page]).per(24)
+    when 'name_asc'
+      @gadgets = Gadget.order('LOWER(name) ASC').page(params[:page]).per(24)
+    when 'name_desc'
+      @gadgets = Gadget.order('LOWER(name) DESC').page(params[:page]).per(24)
+    when 'category_asc'
+      @gadgets = Kaminari.paginate_array(Gadget.all.sort_by { |g| g.category_list.first }).page(params[:page]).per(24)
+    when 'category_desc'
+      @gadgets = Kaminari.paginate_array(Gadget.all.sort_by { |g| g.category_list.first }.reverse).page(params[:page]).per(24)
+    else 'new'
+      @gadgets = Gadget.all.order('created_at DESC').page(params[:page]).per(24)
+    end
+
+    respond_to do |format|
+      format.html
+      format.js
+    end
   end
 
   def show

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -3,18 +3,18 @@ class SearchesController < ApplicationController
     @q = params[:q]
     @model = params[:model].presence || 'gadgets'
     if @q.present?
-        case @model
-        when 'users'
-            @users = User.ransack(name_or_introduction_cont: @q).result(distinct: true)
-        when 'gadgets'
-            @gadgets = Gadget.ransack(name_or_reason_or_usage_or_point_cont: @q).result(distinct: true)
-        when 'categories'
-            @gadgets = Gadget.tagged_with(@q)
-        end
+      case @model
+      when 'users'
+        @users = User.ransack(name_or_introduction_cont: @q).result(distinct: true)
+      when 'gadgets'
+        @gadgets = Gadget.ransack(name_or_reason_or_usage_or_point_cont: @q).result(distinct: true)
+      when 'categories'
+        @gadgets = Gadget.tagged_with(@q)
+      end
     end
     respond_to do |format|
-        format.html
-        format.js
+      format.html
+      format.js
     end
-end
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,26 @@ class UsersController < ApplicationController
   before_action :ensure_correct_user, only: [:edit_profile, :account]
 
   def index
-    @users = User.all.order('created_at DESC').page(params[:page])
+    case params[:order]
+    when 'older'
+      @users = User.all.order('created_at ASC').page(params[:page]).per(24)
+    when 'ranking'
+      @users = User.left_joins(:passive_relationships)
+                .group('users.id')
+                .order('COUNT(relationships.follower_id) DESC')
+                .page(params[:page]).per(24)
+    when 'name_asc'
+      @users = User.order('LOWER(name) ASC').page(params[:page]).per(24)
+    when 'name_desc'
+      @users = User.order('LOWER(name) DESC').page(params[:page]).per(24)
+    else 'new'
+      @users = User.all.order('created_at DESC').page(params[:page]).per(24)
+    end
+
+    respond_to do |format|
+      format.html
+      format.js
+    end
   end
 
   def show_mygadgets

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -145,3 +145,11 @@ $(document).on('turbolinks:load', function() {
     $('#remove_rakuten_url_button').show();
   }
 });
+
+// 投稿一覧ページにて、選択した並び順にactiveクラスを付与する
+$(document).on('turbolinks:load', function() {
+  $('.dropdown-menu .dropdown-item').on('click',function(){
+    $('.dropdown-menu .dropdown-item').removeClass('active');
+    $(this).addClass('active');
+  });
+});

--- a/app/views/gadgets/index.html.erb
+++ b/app/views/gadgets/index.html.erb
@@ -1,55 +1,23 @@
-<% content_for :title, "新着投稿一覧" %>
+<% content_for :title, "投稿一覧" %>
 <div class="container mt-80">
-  <h2 class="form-title">新着投稿一覧</h2>
-  <div class="lists">
-    <div class="row g-4">
-      <% @gadgets.each do |gadget| %>
-        <div class="col-md-6 col-xxl-4">
-          <div class="list-item">
-            <div class="post-container">
-              <div class="content">
-                <%= link_to mygadgets_user_path(gadget.user.id) do %>
-                  <div class="info-container">
-                    <div class="icon-image-sm">
-                      <%= user_avatar_image_tag(gadget.user) %>
-                    </div>
-                    <div class="user-name-and-creationdate-sm">
-                      <p class="user-name-sm"><%= gadget.user.name %></p>
-                      <p class="creationdate-sm"><%= gadget.created_at.to_s(:default) %></p>
-                    </div>
-                  </div>
-                <% end %>
-                <p class="gadget-name"><%= gadget.name %></p>
-                <p class="gadget-category">
-                  <% gadget.category_list.each do |category| %>
-                    <%= link_to category, searches_path(q: category, model: 'categories') %>
-                  <% end %>
-                </p>
-                <%# いいねとコメント %>
-                <div class="likes-and-comments-container d-flex fs-4">
-                  <div class="likes" id="likes-<%= gadget.id %>">
-                    <%= render partial: 'shared/likes', locals: {gadget: gadget} %>
-                  </div>
-                  <div class="comments">
-                    <%= link_to gadget_comments_path(gadget.id), class: "ms-5" do %>
-                      <i class="fa-regular fa-message me-2" style="color: #393e46;"></i> <span><%= gadget.comments.count %></span>
-                    <% end %>
-                  </div>
-                </div>
-              </div>
-              <% if gadget.image.present? %>
-                <div class="gadget-image-md">
-                  <%= image_tag gadget.image %>
-                </div>
-              <% end %>
-            </div>
-            <div class="detail-link-container">
-              <%= link_to "＞ 投稿詳細へ", gadget_path(gadget), class: "btn detail-link" %>
-            </div>
-          </div>
-        </div>
-      <% end %>
+  <h2 class="form-title">投稿一覧</h2>
+  <div class="d-flex">
+    <div class="btn-group dropdown ms-auto">
+      <button class="btn btn-lg dropdown-toggle" type="button" id="dropdownMenuButton1" data-bs-toggle="dropdown" aria-expanded="false">
+        並び替え
+      </button>
+      <ul class="dropdown-menu dropdown-menu-end " aria-labelledby="dropdownMenuButton1">
+        <li><%= link_to "新着順", gadgets_path(order: 'new'), class: "dropdown-item text-dark active", id: "new_order", remote: true %></li>
+        <li><%= link_to "古い順", gadgets_path(order: 'older'), class: "dropdown-item text-dark", id: "older_order", remote: true %></li>
+        <li><%= link_to "人気順", gadgets_path(order: 'ranking'), class: "dropdown-item text-dark", id: "ranking_order", remote: true %></li>
+        <li><%= link_to "昇順(ガジェット名)", gadgets_path(order: 'name_asc'), class: "dropdown-item text-dark", id: "name_asc_order", remote: true %></li>
+        <li><%= link_to "降順(ガジェット名)", gadgets_path(order: 'name_desc'), class: "dropdown-item text-dark", id: "name_desc_order", remote: true %></li>
+        <li><%= link_to "昇順(カテゴリー)", gadgets_path(order: 'category_asc'), class: "dropdown-item text-dark", id: "category_asc_order", remote: true %></li>
+        <li><%= link_to "降順(カテゴリー)", gadgets_path(order: 'category_desc'), class: "dropdown-item text-dark", id: "category_desc_order", remote: true %></li>
+      </ul>
     </div>
   </div>
-  <%= paginate @gadgets %>
+  <div class="lists">
+    <%= render 'shared/gadgets_index_order', gadgets: @gadgets %>
+  </div>
 </div>

--- a/app/views/gadgets/index.html.erb
+++ b/app/views/gadgets/index.html.erb
@@ -1,9 +1,6 @@
 <% content_for :title, "新着投稿一覧" %>
 <div class="container mt-80">
-  <p id="notice"><%= notice %></p>
-
   <h2 class="form-title">新着投稿一覧</h2>
-
   <div class="lists">
     <div class="row g-4">
       <% @gadgets.each do |gadget| %>

--- a/app/views/gadgets/index.html.erb
+++ b/app/views/gadgets/index.html.erb
@@ -6,8 +6,8 @@
       <button class="btn btn-lg dropdown-toggle" type="button" id="dropdownMenuButton1" data-bs-toggle="dropdown" aria-expanded="false">
         並び替え
       </button>
-      <ul class="dropdown-menu dropdown-menu-end " aria-labelledby="dropdownMenuButton1">
-        <li><%= link_to "新着順", gadgets_path(order: 'new'), class: "dropdown-item text-dark active", id: "new_order", remote: true %></li>
+      <ul class="dropdown-menu dropdown-menu-end" id="dropdown_menu" aria-labelledby="dropdownMenuButton1">
+        <li><%= link_to "新着順", gadgets_path(order: 'new'), class: "active dropdown-item text-dark", id: "new_order", remote: true %></li>
         <li><%= link_to "古い順", gadgets_path(order: 'older'), class: "dropdown-item text-dark", id: "older_order", remote: true %></li>
         <li><%= link_to "人気順", gadgets_path(order: 'ranking'), class: "dropdown-item text-dark", id: "ranking_order", remote: true %></li>
         <li><%= link_to "昇順(ガジェット名)", gadgets_path(order: 'name_asc'), class: "dropdown-item text-dark", id: "name_asc_order", remote: true %></li>

--- a/app/views/gadgets/index.js.erb
+++ b/app/views/gadgets/index.js.erb
@@ -1,0 +1,1 @@
+$(".lists").html("<%= escape_javascript(render('shared/gadgets_index_order', gadgets: @gadgets)) %>");

--- a/app/views/gadgets/top.html.erb
+++ b/app/views/gadgets/top.html.erb
@@ -57,7 +57,7 @@
 <div class="container mt-120">
   <div class="lists-title">
     <h2>新着投稿一覧</h2>
-    <%= link_to "新着投稿一覧はこちら", gadgets_path %>
+    <%= link_to "投稿一覧はこちら", gadgets_path %>
   </div>
   <div class="lists">
     <div class="row g-4">
@@ -110,7 +110,7 @@
     </div>
   </div>
   <div class="list-link-container mt-5">
-    <%= link_to "新着投稿一覧はこちら", gadgets_path, class: "btn list-link" %>
+    <%= link_to "投稿一覧はこちら", gadgets_path, class: "btn list-link" %>
   </div>
 </div>
 <div class="container mt-80">

--- a/app/views/gadgets/top.html.erb
+++ b/app/views/gadgets/top.html.erb
@@ -33,7 +33,6 @@
     </div>
   </div>
 <% end %>
-
 <div class="container mt-48">
   <hr class="search-border">
   <P class="mt-5 text-center fs-2 fw-bold">キーワードで検索</P>
@@ -50,10 +49,7 @@
       </div>
     </div>
   <% end %>
-  <%# <hr class="search-border"> %>
-
 </div>
-
 <div class="container mt-120">
   <div class="lists-title">
     <h2>新着投稿一覧</h2>
@@ -78,11 +74,11 @@
                   </div>
                 <% end %>
                 <p class="gadget-name"><%= gadget.name %></p>
-                <p class="gadget-category">
-                  <% gadget.category_list.each do |category| %>
+                <% gadget.category_list.each do |category| %>
+                  <p class="gadget-category">
                     <%= link_to category, searches_path(q: category, model: 'categories') %>
-                  <% end %>
-                </p>
+                  </p>
+                <% end %>
                 <%# いいねとコメント %>
                 <div class="likes-and-comments-container d-flex fs-4">
                   <div class="likes" id="likes-<%= gadget.id %>">

--- a/app/views/shared/_gadgets_index_order.html.erb
+++ b/app/views/shared/_gadgets_index_order.html.erb
@@ -1,0 +1,49 @@
+<div class="row g-4">
+  <% gadgets.each do |gadget| %>
+    <div class="col-md-6 col-xxl-4">
+      <div class="list-item">
+        <div class="post-container">
+          <div class="content">
+            <%= link_to mygadgets_user_path(gadget.user.id) do %>
+              <div class="info-container">
+                <div class="icon-image-sm">
+                  <%= user_avatar_image_tag(gadget.user) %>
+                </div>
+                <div class="user-name-and-creationdate-sm">
+                  <p class="user-name-sm"><%= gadget.user.name %></p>
+                  <p class="creationdate-sm"><%= gadget.created_at.to_s(:default) %></p>
+                </div>
+              </div>
+            <% end %>
+            <p class="gadget-name"><%= gadget.name %></p>
+            <p class="gadget-category">
+              <% gadget.category_list.each do |category| %>
+                <%= link_to category, searches_path(q: category, model: 'categories') %>
+              <% end %>
+            </p>
+            <%# いいねとコメント %>
+            <div class="likes-and-comments-container d-flex fs-4">
+              <div class="likes" id="likes-<%= gadget.id %>">
+                <%= render partial: 'shared/likes', locals: {gadget: gadget} %>
+              </div>
+              <div class="comments">
+                <%= link_to gadget_comments_path(gadget.id), class: "ms-5" do %>
+                  <i class="fa-regular fa-message me-2" style="color: #393e46;"></i> <span><%= gadget.comments.count %></span>
+                <% end %>
+              </div>
+            </div>
+          </div>
+          <% if gadget.image.present? %>
+            <div class="gadget-image-md">
+              <%= image_tag gadget.image %>
+            </div>
+          <% end %>
+        </div>
+        <div class="detail-link-container">
+          <%= link_to "＞ 投稿詳細へ", gadget_path(gadget), class: "btn detail-link" %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</div>
+<%= paginate gadgets, params: { order: params[:order] }, remote: true %>

--- a/app/views/shared/_gadgets_index_order.html.erb
+++ b/app/views/shared/_gadgets_index_order.html.erb
@@ -16,11 +16,11 @@
               </div>
             <% end %>
             <p class="gadget-name"><%= gadget.name %></p>
-            <p class="gadget-category">
-              <% gadget.category_list.each do |category| %>
+            <% gadget.category_list.each do |category| %>
+              <p class="gadget-category">
                 <%= link_to category, searches_path(q: category, model: 'categories') %>
-              <% end %>
-            </p>
+              </p>
+            <% end %>
             <%# いいねとコメント %>
             <div class="likes-and-comments-container d-flex fs-4">
               <div class="likes" id="likes-<%= gadget.id %>">

--- a/app/views/shared/_login_user_header.html.erb
+++ b/app/views/shared/_login_user_header.html.erb
@@ -12,7 +12,7 @@
           <li><%= link_to "マイページ", mygadgets_user_path(current_user.id), class: "dropdown-item" %></li>
           <li><%= link_to "ガジェット登録", new_gadget_path, class: "dropdown-item" %></li>
           <li><%= link_to "ユーザー一覧", users_path, class: "dropdown-item" %></li>
-          <li><%= link_to "新着投稿一覧", gadgets_path, class: "dropdown-item" %></li>
+          <li><%= link_to "投稿一覧", gadgets_path, class: "dropdown-item" %></li>
           <li><%= link_to "アカウント情報", account_user_path(current_user.id), class: "dropdown-item" %></li>
           <li><%= link_to "ログアウト", destroy_user_session_path, class: "dropdown-item", method: :delete %></li>
           <li><%= link_to "お問い合わせ", contact_path, class: "dropdown-item" %></li>

--- a/app/views/shared/_logout_user_header.html.erb
+++ b/app/views/shared/_logout_user_header.html.erb
@@ -19,7 +19,7 @@
             <li><%= link_to "新規登録", new_user_registration_path, class: "dropdown-item" %></li>
             <li><%= link_to "ログイン", new_user_session_path, class: "dropdown-item" %></li>
             <li><%= link_to "ユーザー一覧", users_path, class: "dropdown-item" %></li>
-            <li><%= link_to "新着投稿一覧", gadgets_path, class: "dropdown-item" %></li>
+            <li><%= link_to "投稿一覧", gadgets_path, class: "dropdown-item" %></li>
             <li><%= link_to "お問い合わせ", contact_path, class: "dropdown-item" %></li>
           </ul>
         </div>

--- a/app/views/shared/_search_gadget_page.html.erb
+++ b/app/views/shared/_search_gadget_page.html.erb
@@ -17,11 +17,11 @@
                 </div>
               <% end %>
               <p class="gadget-name"><%= gadget.name %></p>
-              <p class="gadget-category">
-                <% gadget.category_list.each do |category| %>
+              <% gadget.category_list.each do |category| %>
+                <p class="gadget-category">
                   <%= link_to category, searches_path(q: category, model: 'categories') %>
-                <% end %>
-              </p>
+                </p>
+              <% end %>
               <%# いいねとコメント %>
               <div class="likes-and-comments-container d-flex fs-4">
                 <div class="likes" id="likes-<%= gadget.id %>">

--- a/app/views/shared/_users_index_order.html.erb
+++ b/app/views/shared/_users_index_order.html.erb
@@ -1,0 +1,50 @@
+<div class="row g-4">
+  <% users.each do |user| %>
+    <div class="col-md-6 col-xxl-4">
+      <div class="list-item">
+        <div class="d-flex justify-content-between align-items-center">
+          <%= link_to mygadgets_user_path(user.id) do %>
+            <div class="info-container">
+              <div class="icon-image-sm">
+                <%= user_avatar_image_tag(user) %>
+              </div>
+              <div class="user-name-only">
+                <p class="user-name"><%= user.name %></p>
+              </div>
+            </div>
+          <% end %>
+          <% if user_signed_in? %>
+            <div id="follow-form-<%= user.id %>">
+              <%= render 'shared/follow-and-unfollow', user: user %>
+            </div>
+          <% end %>
+        </div>
+        <div class="gadget-image-sm">
+          <div class="row">
+            <% user.gadgets.each do |gadget| %>
+              <% if gadget.image.present? %>
+                <div class="col-3 my-2">
+                  <%= link_to gadget_path(gadget.id) do %>
+                    <%= image_tag gadget.image %>
+                  <% end %>
+                </div>
+              <% end %>
+            <% end %>
+          </div>
+        </div>
+        <div class="ps-2">
+          <%= link_to user_followings_path(user) do %>
+            <span class="fs-5"><strong><%= user.followings.count %></strong> フォロー</span>
+          <% end %>
+          <%= link_to user_followers_path(user) do %>
+            <span class="fs-5 ms-4"><strong><%= user.followers.count %></strong> フォロワー</span>
+          <% end %>
+        </div>
+        <div class="detail-link-container">
+          <P><%= link_to "＞ ユーザー詳細へ", mygadgets_user_path(user.id), class: "btn detail-link" %></P>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</div>
+<%= paginate users, params: { order: params[:order] }, remote: true %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,56 +1,21 @@
 <% content_for :title, "ユーザー一覧" %>
 <div class="container">
   <h2 class="form-title">ユーザー一覧</h2>
-  <div class="lists">
-    <div class="row g-4">
-      <% @users.each do |user| %>
-        <div class="col-md-6 col-xxl-4">
-          <div class="list-item">
-            <div class="d-flex justify-content-between align-items-center">
-              <%= link_to mygadgets_user_path(user.id) do %>
-                <div class="info-container">
-                  <div class="icon-image-sm">
-                    <%= user_avatar_image_tag(user) %>
-                  </div>
-                  <div class="user-name-only">
-                    <p class="user-name"><%= user.name %></p>
-                  </div>
-                </div>
-              <% end %>
-              <% if user_signed_in? %>
-                <div id="follow-form-<%= user.id %>">
-                  <%= render 'shared/follow-and-unfollow', user: user %>
-                </div>
-              <% end %>
-            </div>
-            <div class="gadget-image-sm">
-              <div class="row">
-                <% user.gadgets.each do |gadget| %>
-                  <% if gadget.image.present? %>
-                    <div class="col-3 my-2">
-                      <%= link_to gadget_path(gadget.id) do %>
-                        <%= image_tag gadget.image %>
-                      <% end %>
-                    </div>
-                  <% end %>
-                <% end %>
-              </div>
-            </div>
-            <div class="ps-2">
-              <%= link_to user_followings_path(user) do %>
-                <span class="fs-5"><strong><%= user.followings.count %></strong> フォロー</span>
-              <% end %>
-              <%= link_to user_followers_path(user) do %>
-                <span class="fs-5 ms-4"><strong><%= user.followers.count %></strong> フォロワー</span>
-              <% end %>
-            </div>
-            <div class="detail-link-container">
-              <P><%= link_to "＞ ユーザー詳細へ", mygadgets_user_path(user.id), class: "btn detail-link" %></P>
-            </div>
-          </div>
-        </div>
-      <% end %>
+  <div class="d-flex">
+    <div class="btn-group dropdown ms-auto">
+      <button class="btn btn-lg dropdown-toggle" type="button" id="dropdownMenuButton1" data-bs-toggle="dropdown" aria-expanded="false">
+        並び替え
+      </button>
+      <ul class="dropdown-menu dropdown-menu-end " aria-labelledby="dropdownMenuButton1">
+        <li><%= link_to "新着順", users_path(order: 'new'), class: "dropdown-item text-dark active", id: "new_order", remote: true %></li>
+        <li><%= link_to "古い順", users_path(order: 'older'), class: "dropdown-item text-dark", id: "older_order", remote: true %></li>
+        <li><%= link_to "人気順", users_path(order: 'ranking'), class: "dropdown-item text-dark", id: "ranking_order", remote: true %></li>
+        <li><%= link_to "昇順(ユーザー名)", users_path(order: 'name_asc'), class: "dropdown-item text-dark", id: "name_asc_order", remote: true %></li>
+        <li><%= link_to "降順(ユーザー名)", users_path(order: 'name_desc'), class: "dropdown-item text-dark", id: "name_desc_order", remote: true %></li>
+      </ul>
     </div>
   </div>
-  <%= paginate @users %>
+  <div class="lists">
+    <%= render 'shared/users_index_order', users: @users %>
+  </div>
 </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,9 +1,6 @@
 <% content_for :title, "ユーザー一覧" %>
 <div class="container">
-  <p id="notice"><%= notice %></p>
-
   <h2 class="form-title">ユーザー一覧</h2>
-
   <div class="lists">
     <div class="row g-4">
       <% @users.each do |user| %>

--- a/app/views/users/index.js.erb
+++ b/app/views/users/index.js.erb
@@ -1,0 +1,1 @@
+$(".lists").html("<%= escape_javascript(render('shared/users_index_order', users: @users)) %>");

--- a/app/views/users/show_favorites.html.erb
+++ b/app/views/users/show_favorites.html.erb
@@ -64,11 +64,11 @@
                 </div>
               <% end %>
               <p class="gadget-name"><%= gadget.name %></p>
-              <p class="gadget-category">
-                <% gadget.category_list.each do |category| %>
+              <% gadget.category_list.each do |category| %>
+                <p class="gadget-category">
                   <%= link_to category, searches_path(q: category, model: 'categories') %>
-                <% end %>
-              </p>
+                </p>
+              <% end %>
               <%# いいねとコメント %>
               <div class="likes-and-comments-container d-flex fs-4">
                 <div class="likes" id="likes-<%= gadget.id %>">

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 Kaminari.configure do |config|
-  config.default_per_page = 10
-  config.max_per_page = 10
+  config.default_per_page = 12
+  # config.max_per_page = 10
   config.window = 1
   # config.outer_window = 1
   # config.left = 1

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,43 @@
 require 'faker'
 
+# 開発環境用
 # Userのダミーデータ作成
-20.times do
+# 20.times do
+#   # 改行を含む２or３行の文を作成し、変数introductionに代入
+#   introduction = "#{Faker::Lorem.sentence}\n#{Faker::Lorem.sentence}"
+#   introduction += "\n#{Faker::Lorem.sentence}" if rand(2) == 1
+
+#   user = User.create!(
+#     email: Faker::Internet.unique.email,
+#     password: 'password', # 仮のパスワードを入力
+#     name: Faker::Name.name,
+#     introduction: introduction,
+#   )
+
+#   # ActiveStorageで画像を添付
+#   user.avatar.attach(io: File.open('app/assets/images/default_icon_image.png'), filename: 'default_icon_image.png', content_type: 'image/png')
+# end
+
+# # Gadgetのダミーデータ作成
+# 20.times do
+#   gadget = Gadget.create!(
+#     name: Faker::Device.model_name,
+#     start_date: Faker::Date.between(from: 10.years.ago, to: Date.today),
+#     category: Faker::Commerce.department(max: 1),
+#     reason: Faker::Lorem.sentences(number: 3).join("\n"),
+#     point: Faker::Lorem.sentences(number: 3).join("\n"),
+#     usage: Faker::Lorem.sentences(number: 3).join("\n"),
+#     user_id: User.all.sample.id # ランダムなユーザーIDを入力
+#   )
+
+#   # ActiveStorageで画像を添付
+#   gadget.image.attach(io: File.open('app/assets/images/sample_gadget_image.jpg'), filename: 'sample_gadget_image.jpg', content_type: 'image/jpg
+#   ')
+# end
+
+# 本番環境用
+# Userのダミーデータ作成
+25.times do
   # 改行を含む２or３行の文を作成し、変数introductionに代入
   introduction = "#{Faker::Lorem.sentence}\n#{Faker::Lorem.sentence}"
   introduction += "\n#{Faker::Lorem.sentence}" if rand(2) == 1
@@ -9,27 +45,20 @@ require 'faker'
   user = User.create!(
     email: Faker::Internet.unique.email,
     password: 'password', # 仮のパスワードを入力
-    name: Faker::Name.name,
+    name: Faker::Internet.unique.username,
     introduction: introduction,
   )
-
-  # ActiveStorageで画像を添付
-  user.avatar.attach(io: File.open('app/assets/images/default_icon_image.png'), filename: 'default_icon_image.png', content_type: 'image/png')
 end
 
 # Gadgetのダミーデータ作成
-20.times do
+25.times do
   gadget = Gadget.create!(
     name: Faker::Device.model_name,
     start_date: Faker::Date.between(from: 10.years.ago, to: Date.today),
-    category: Faker::Commerce.department(max: 1),
+    category_list: Faker::Device.manufacturer,
     reason: Faker::Lorem.sentences(number: 3).join("\n"),
     point: Faker::Lorem.sentences(number: 3).join("\n"),
     usage: Faker::Lorem.sentences(number: 3).join("\n"),
     user_id: User.all.sample.id # ランダムなユーザーIDを入力
   )
-
-  # ActiveStorageで画像を添付
-  gadget.image.attach(io: File.open('app/assets/images/sample_gadget_image.jpg'), filename: 'sample_gadget_image.jpg', content_type: 'image/jpg
-  ')
 end

--- a/spec/factories/gadgets.rb
+++ b/spec/factories/gadgets.rb
@@ -1,9 +1,21 @@
 FactoryBot.define do
   factory :gadget do
     user
-    name { Faker::Device.model_name }
-    category_list { Faker::Commerce.department(max: 1) }
+    sequence(:name) { |n| ('a'.ord + (n - 1) % 26).chr + "_ガジェット" }
+    category_list { Faker::Commerce.department(max: 3) }
     point { Faker::Lorem.sentence }
+    sequence(:created_at) { |n| Time.current - n.hours }
+
+    # gadgetにlikeを紐づける
+    transient do
+      likes_count { 0 }
+    end
+
+    after(:create) do |gadget, evaluator|
+      evaluator.likes_count.times do
+        create(:like, gadget: gadget, user: create(:user))
+      end
+    end
 
     # gadgetに画像を添付する
     after(:create) do |gadget|
@@ -12,4 +24,3 @@ FactoryBot.define do
     end
   end
 end
-

--- a/spec/factories/likes.rb
+++ b/spec/factories/likes.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :like do
-    association :user
+    # association :user
     association :gadget
   end
 end

--- a/spec/system/gadgets/index_spec.rb
+++ b/spec/system/gadgets/index_spec.rb
@@ -1,0 +1,193 @@
+require 'rails_helper'
+
+RSpec.describe "Gadgets", type: :system do
+  let!(:user) { create(:user) }
+
+  context "ページネーションなし" do
+    let!(:gadgets) do
+      [
+        create(:gadget, created_at: 3.hours.ago, likes_count: 5, name: "c_gadget", category_list: ["スマホ", "メインスマホ"]),
+        create(:gadget, created_at: 2.hours.ago, likes_count: 3, name: "D_gadget", category_list: ["タブレット", "サブタブレット"]),
+        create(:gadget, created_at: 1.hour.ago, likes_count: 10, name: "f_gadget", category_list: ["メインPC", "PC"]),
+      ]
+    end
+
+    before do
+      sign_in user
+      visit gadgets_path
+    end
+
+    it "並び替えボタンをクリックするとドロップダウンが展開し”新着順”に背景色が設定されている", js: true do
+      find('#dropdownMenuButton1').click
+      within("#dropdown_menu") do
+        expect(page).to have_css("#new_order.active")
+      end
+    end
+
+    it "投稿一覧ページ遷移時は、新着順に投稿が表示されている", js: true do
+      displayed_gadgets = all('.post-container')
+      expect(displayed_gadgets.first).to have_content gadgets.last.name
+      expect(displayed_gadgets.last).to have_content gadgets.first.name
+    end
+
+    it "”人気順”から”新着順”を選択すると新着順に表示される", js: true do
+      find('#dropdownMenuButton1').click
+      click_on '人気順'
+      wait_for_ajax
+      find('#dropdownMenuButton1').click
+      click_on '新着順'
+      wait_for_ajax
+      find('#dropdownMenuButton1').click
+      within("#dropdown_menu") do
+        expect(page).to have_css("#new_order.active")
+      end
+      wait_for_ajax
+      find('#dropdownMenuButton1').click
+      wait_for_ajax
+
+      displayed_gadgets = all('.post-container')
+      expect(displayed_gadgets.first).to have_content gadgets.last.name
+      expect(displayed_gadgets.last).to have_content gadgets.first.name
+    end
+
+    it "”古い順を選択すると古い順に表示される”", js: true do
+      find('#dropdownMenuButton1').click
+      click_on '古い順'
+      wait_for_ajax
+      find('#dropdownMenuButton1').click
+      within("#dropdown_menu") do
+        expect(page).to have_css("#older_order.active")
+      end
+      wait_for_ajax
+      find('#dropdownMenuButton1').click
+      wait_for_ajax
+
+      displayed_gadgets = all('.post-container')
+      expect(displayed_gadgets.first).to have_content gadgets.first.name
+      expect(displayed_gadgets.last).to have_content gadgets.last.name
+    end
+
+    it "”人気順”を選択するといいね数が多い順に並び替えられ、新着順の背景色がなくなり、選択した人気順に背景色が適用される。", js: true do
+      find('#dropdownMenuButton1').click
+      click_on '人気順'
+      wait_for_ajax
+      find('#dropdownMenuButton1').click
+      within("#dropdown_menu") do
+        expect(page).to have_css("#ranking_order.active")
+      end
+      wait_for_ajax
+      find('#dropdownMenuButton1').click
+      wait_for_ajax
+
+      displayed_gadgets = all('.post-container')
+      expect(displayed_gadgets.first).to have_content gadgets[2].name
+      expect(displayed_gadgets.last).to have_content gadgets[1].name
+    end
+
+    it "昇順（ガジェット名）を選択すると、大小文字関係なくアルファベット順に表示される", js: true do
+      find('#dropdownMenuButton1').click
+      click_on '昇順(ガジェット名)'
+      wait_for_ajax
+      find('#dropdownMenuButton1').click
+      within("#dropdown_menu") do
+        expect(page).to have_css("#name_asc_order.active")
+      end
+      wait_for_ajax
+      find('#dropdownMenuButton1').click
+      wait_for_ajax
+
+      displayed_gadgets = all('.post-container')
+      expect(displayed_gadgets.first).to have_content gadgets[0].name
+      expect(displayed_gadgets.last).to have_content gadgets[2].name
+    end
+
+    it "降順（ガジェット名）を選択すると、大小文字関係なくアルファベット逆順に表示される", js: true do
+      find('#dropdownMenuButton1').click
+      click_on '降順(ガジェット名)'
+      wait_for_ajax
+      find('#dropdownMenuButton1').click
+      within("#dropdown_menu") do
+        expect(page).to have_css("#name_desc_order.active")
+      end
+      wait_for_ajax
+      find('#dropdownMenuButton1').click
+      wait_for_ajax
+
+      displayed_gadgets = all('.post-container')
+      expect(displayed_gadgets.first).to have_content gadgets[2].name
+      expect(displayed_gadgets.last).to have_content gadgets[0].name
+    end
+
+  end
+
+  context "ページネーションあり" do
+    let!(:gadgets) { create_list(:gadget, 26, user: user) }
+
+    before do
+      sign_in user
+      visit gadgets_path
+    end
+
+    it "投稿数が25以上の場合、ページネーションが表示され２ページ目をクリックすると、新着順のまま２ページ目へ遷移する", js: true do
+      wait_for_ajax
+      expect(page).to have_css('.pagination')
+
+      # １ページ目の最後のガジェットを取得
+      first_page_last_gadget = all('.post-container').last
+      new_gadget = first_page_last_gadget.find('.gadget-name').text
+      first_page_last_gadget_created_at = Gadget.find_by(name: new_gadget).created_at # １ページ目の最後のガジェットの作成日時を取得
+
+      element = find('.pagination .page-item:nth-child(2) a')
+      page.execute_script("arguments[0].scrollIntoView(true)", element.native)
+      element.click
+      wait_for_ajax
+      expect(page).not_to have_content(first_page_last_gadget.text)
+
+      # ２ページ目の最後のガジェットを取得
+      second_page_first_gadget = all('.post-container').first
+      older_gadget = second_page_first_gadget.find('.gadget-name').text
+      second_page_first_gadget_created_at = Gadget.find_by(name: older_gadget).created_at # １ページ目の最後のガジェットの作成日時を取得
+      expect(second_page_first_gadget_created_at).to be < first_page_last_gadget_created_at
+      find('#dropdownMenuButton1').click
+      within("#dropdown_menu") do
+        expect(page).to have_css("#new_order.active")
+      end
+    end
+
+    it "投稿数が25以上の場合、昇順（ガジェット名）を選択し2ページ目をクリックすると、昇順（ガジェット名）のまま2ページ目へ遷移する", js: true do
+      wait_for_ajax
+      expect(page).to have_css('.pagination')
+      find('#dropdownMenuButton1').click
+      click_on '昇順(ガジェット名)'
+      wait_for_ajax
+      find('#dropdownMenuButton1').click
+      within("#dropdown_menu") do
+        expect(page).to have_css("#name_asc_order.active")
+      end
+      wait_for_ajax
+      find('#dropdownMenuButton1').click
+      wait_for_ajax
+
+      # １ページ目の最後のガジェットを取得
+      first_page_last_gadget = all('.post-container').last
+      new_gadget = first_page_last_gadget.find('.gadget-name').text
+
+      element = find('.pagination .page-item:nth-child(2) a')
+      page.execute_script("arguments[0].scrollIntoView(true)", element.native)
+      element.click
+      wait_for_ajax
+      expect(page).not_to have_content(new_gadget)
+
+      # ２ページ目の最後のガジェットを取得
+      second_page_first_gadget = all('.post-container').first
+      older_gadget = second_page_first_gadget.find('.gadget-name').text
+
+      expect(older_gadget).to be > new_gadget
+      find('#dropdownMenuButton1').click
+      within("#dropdown_menu") do
+        expect(page).to have_css("#name_asc_order.active")
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
#192 
【実装機能概要】
- 投稿一覧ページに以下並び替え機能を追加
  - 新着順
  - 古い順
  - 人気順
  - 昇順（ガジェット名）
  - 降順（ガジェット名）
  - 昇順（カテゴリー）
  - 降順（カテゴリー）
- ユーザー一覧ページに以下並び替え機能を追加
  - 新着順
  - 古い順
  - 人気順
  - 昇順（ユーザー名）
  - 降順（ユーザー名）
- それぞれの並び替えの切り替えは非同期通信にて切り替え可能
- 選択している並び替えが何かわかるように選択している並び替え項目の背景色を変更する機能を実装
- トップページでの投稿・ユーザー一覧の表示件数を9件／1ページに、投稿・ユーザー一覧ページの表示件数を24件／1ページに変更
- テスト実装